### PR TITLE
Gracefully abort install when .env is missing

### DIFF
--- a/src/Commands/NotifierInstallCommand.php
+++ b/src/Commands/NotifierInstallCommand.php
@@ -5,16 +5,18 @@ namespace Devuni\Notifier\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
-
 class NotifierInstallCommand extends Command
 {
     protected $signature = 'notifier:install';
+
     protected $description = 'Configure environment variables for Notifier package';
 
     public function handle()
     {
         $this->displayBanner();
-        $this->ensureEnvFileExists();
+        if ($this->ensureEnvFileExists() === static::FAILURE) {
+            return static::FAILURE;
+        }
         $this->newLine();
 
         $this->info('🔧 Please provide the required environment values:');
@@ -32,25 +34,29 @@ class NotifierInstallCommand extends Command
 
         $this->newLine();
         $this->info('✅ Notifier environment configuration was saved successfully!');
+
+        return static::SUCCESS;
     }
 
-    private function ensureEnvFileExists() : void 
+    private function ensureEnvFileExists(): int
     {
-        if (!File::exists(base_path('.env'))){
+        if (! File::exists(base_path('.env'))) {
             $this->warn('❗ .env file does not exists.');
 
             if ($this->confirm('Do you want to create it from .env.example', true)) {
                 File::copy(base_path('.env.example'), base_path('.env'));
                 $this->info('✅ .env file created from env.example');
-            } 
-            else {
+            } else {
                 $this->error('❌ Installation aborted. .env file is required.');
-                exit(1);
+
+                return static::FAILURE;
             }
         }
+
+        return static::SUCCESS;
     }
 
-    private function askRequired(string $question) : string 
+    private function askRequired(string $question): string
     {
         do {
             $value = $this->ask($question);
@@ -62,19 +68,19 @@ class NotifierInstallCommand extends Command
         return $value;
     }
 
-    private function updateEnv(array $data) : void
+    private function updateEnv(array $data): void
     {
         $envPath = base_path('.env');
         $envContent = file_get_contents($envPath);
 
-        foreach($data as $key => $value) {
+        foreach ($data as $key => $value) {
             $pattern = "/^{$key}=.*$/m";
             $line = "{$key}=\"{$value}\"";
 
             if (preg_match($pattern, $envContent)) {
                 $envContent = preg_replace($pattern, $line, $envContent);
             } else {
-                $envContent .= PHP_EOL . $line;
+                $envContent .= PHP_EOL.$line;
             }
         }
 
@@ -97,7 +103,7 @@ class NotifierInstallCommand extends Command
         $this->line('<fg=bright-blue>📁 Repository:</>       <fg=cyan;options=underscore>https://github.com/devuni-cz/notifier-package</>');
         $this->line('<fg=bright-blue>🌐 Website:</>          <fg=cyan;options=underscore>https://devuni.cz</>');
         $this->line('<fg=bright-blue>🔨 Developed by:</>     <fg=white>Devuni team</>');
-        $this->line('<fg=bright-blue>📅 Version:</>          <fg=white>'. $this->getCurrentVersion() . '</>');
+        $this->line('<fg=bright-blue>📅 Version:</>          <fg=white>'.$this->getCurrentVersion().'</>');
         $this->line('<fg=gray>──────────────────────────────────────────────────────────────────────────────</>');
         $this->newLine();
     }
@@ -105,8 +111,7 @@ class NotifierInstallCommand extends Command
     private function getCurrentVersion(): string
     {
         $json = json_decode(shell_exec('composer show devuni/notifier-package --format=json'), true);
+
         return $json['versions'][0] ?? 'unkown';
     }
 }
-
-

--- a/tests/Feature/PackageInstallationTest.php
+++ b/tests/Feature/PackageInstallationTest.php
@@ -2,12 +2,32 @@
 
 declare(strict_types=1);
 
-it('can install the package', function () {
-    // Test that the package can be installed and configured
-    expect(true)->toBeTrue();
+use Illuminate\Console\Command;
+
+it('returns failure when .env creation is declined', function () {
+    $envPath = base_path('.env');
+    if (file_exists($envPath)) {
+        unlink($envPath);
+    }
+
+    $this->artisan('notifier:install')
+        ->expectsConfirmation('Do you want to create it from .env.example', 'no')
+        ->assertExitCode(Command::FAILURE);
 });
 
-it('can publish configuration', function () {
-    // Test configuration publishing
-    expect(true)->toBeTrue();
+it('returns success when environment is configured', function () {
+    $envPath = base_path('.env');
+    if (file_exists($envPath)) {
+        unlink($envPath);
+    }
+
+    $this->artisan('notifier:install')
+        ->expectsConfirmation('Do you want to create it from .env.example', 'yes')
+        ->expectsQuestion('BACKUP_CODE: ', 'code')
+        ->expectsQuestion('BACKUP_URL: ', 'https://example.com')
+        ->expectsQuestion('BACKUP_ZIP_PASSWORD: ', 'secret')
+        ->assertExitCode(Command::SUCCESS);
+
+    expect(file_exists($envPath))->toBeTrue();
+    unlink($envPath);
 });


### PR DESCRIPTION
## Summary
- Avoid exiting and return failure when user declines to create `.env`
- Stop installation early if `.env` is absent
- Cover installer return codes with tests

## Testing
- `composer test`
- `composer analyse` *(fails: At least one path must be specified to analyse.)*


------
https://chatgpt.com/codex/tasks/task_b_6896032b386483289ba53f4c94930e58