### PR TITLE
Ensure backup files use restrictive permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Laravel 12 package for automated database backups and notifications.
 -   Multiple notification channels (email, Slack, etc.)
 -   Configurable backup schedules
 -   Backup verification and validation
+-   Backup files created with restrictive permissions (0600)
 -   Comprehensive logging
 -   Easy configuration and customization
 

--- a/config/notifier.php
+++ b/config/notifier.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    // Backup ZIP files are stored with permissions 0600 (read/write for owner only)
     'backup_code' => env('BACKUP_CODE'),
     'backup_url' => env('BACKUP_URL'),
     'backup_zip_password' => env('BACKUP_ZIP_PASSWORD', 'secret123'),

--- a/src/Services/NotifierStorageService.php
+++ b/src/Services/NotifierStorageService.php
@@ -64,8 +64,10 @@ class NotifierStorageService
 
             Log::channel('backup')->info('➡️ closing the backup file');
             $zip->close();
-
-            chmod($path, 0777);
+            if (! chmod($path, 0600)) {
+                Log::channel('backup')->error('❌ failed to set backup file permissions', ['path' => $path]);
+                throw new \RuntimeException('Unable to set backup file permissions for '.$path);
+            }
         }
 
         Log::channel('backup')->info($path);


### PR DESCRIPTION
## Summary
- use 0600 permissions for generated backup archives and fail with log if permissions can't be set
- document backup file permissions in configuration and README

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68960342bf408328a79356a8d4ca5ab9