### PR TITLE
Add backup parameter validation and failure tests

### DIFF
--- a/src/Controllers/NotifierController.php
+++ b/src/Controllers/NotifierController.php
@@ -2,7 +2,6 @@
 
 namespace Devuni\Notifier\Controllers;
 
-use App\Http\Controllers\Controller;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -13,6 +12,8 @@ class NotifierController
 {
     public function __invoke(Request $request): JsonResponse
     {
+        $request->validate(['param' => 'required|in:backup_database,backup_storage']);
+
         if ($response = $this->checkEnvironment()) {
             return $response;
         }
@@ -86,7 +87,7 @@ class NotifierController
             return response()->json([
                 'message' => 'Storage backup failed.',
                 'error' => $e->getMessage(),
-            ]);
+            ], 500);
         }
     }
 

--- a/tests/Feature/NotifierControllerTest.php
+++ b/tests/Feature/NotifierControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+
+it('validates param', function (string $uri) {
+    $response = $this->getJson($uri);
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors(['param']);
+})->with([
+    'missing' => '/api/backup',
+    'invalid' => '/api/backup?param=invalid',
+]);
+
+it('returns error when database backup fails', function () {
+    config([
+        'notifier.backup_code' => 'code',
+        'notifier.backup_url' => 'url',
+        'notifier.backup_zip_password' => 'pass',
+    ]);
+
+    Artisan::swap(new class
+    {
+        public function call($command, array $parameters = [], $outputBuffer = null)
+        {
+            throw new Exception('test error');
+        }
+    });
+
+    $response = $this->getJson('/api/backup?param=backup_database');
+
+    $response->assertStatus(500);
+    $response->assertJson([
+        'message' => 'Database backup failed.',
+        'error' => 'test error',
+    ]);
+});
+
+it('returns error when storage backup fails', function () {
+    config([
+        'notifier.backup_code' => 'code',
+        'notifier.backup_url' => 'url',
+        'notifier.backup_zip_password' => 'pass',
+    ]);
+
+    Artisan::swap(new class
+    {
+        public function call($command, array $parameters = [], $outputBuffer = null)
+        {
+            throw new Exception('test error');
+        }
+    });
+
+    $response = $this->getJson('/api/backup?param=backup_storage');
+
+    $response->assertStatus(500);
+    $response->assertJson([
+        'message' => 'Storage backup failed.',
+        'error' => 'test error',
+    ]);
+});


### PR DESCRIPTION
## Summary
- validate backup type parameter before dispatch
- return 500 status when storage backup fails
- test invalid parameters and backup failure branches

## Testing
- `composer test`
- `composer analyse` *(fails: At least one path must be specified to analyse.)*


------
https://chatgpt.com/codex/tasks/task_b_689603433d28832889b8e95885f677fe