### PR TITLE
Add service coverage tests and installation feature checks

### DIFF
--- a/tests/Feature/PackageInstallationTest.php
+++ b/tests/Feature/PackageInstallationTest.php
@@ -2,12 +2,37 @@
 
 declare(strict_types=1);
 
+namespace Devuni\Notifier\Commands {
+    function shell_exec($command) {
+        return json_encode(['versions' => ['test-version']]);
+    }
+}
+
+namespace {
+use Illuminate\Support\Facades\File;
+
 it('can install the package', function () {
-    // Test that the package can be installed and configured
-    expect(true)->toBeTrue();
+    File::put(base_path('.env'), '');
+    File::put(base_path('.env.example'), '');
+
+    $this->artisan('notifier:install')
+        ->expectsQuestion('BACKUP_CODE: ', 'code')
+        ->expectsQuestion('BACKUP_URL: ', 'http://example.com')
+        ->expectsQuestion('BACKUP_ZIP_PASSWORD: ', 'zip')
+        ->assertExitCode(0);
+
+    $env = File::get(base_path('.env'));
+    expect($env)->toContain('BACKUP_CODE="code"', 'BACKUP_URL="http://example.com"', 'BACKUP_ZIP_PASSWORD="zip"');
 });
 
 it('can publish configuration', function () {
-    // Test configuration publishing
-    expect(true)->toBeTrue();
+    $configPath = config_path('notifier.php');
+    if (File::exists($configPath)) {
+        File::delete($configPath);
+    }
+
+    $this->artisan('vendor:publish', ['--tag' => 'config', '--force' => true])->assertExitCode(0);
+
+    expect(File::exists($configPath))->toBeTrue();
 });
+}

--- a/tests/Unit/NotifierDatabaseServiceTest.php
+++ b/tests/Unit/NotifierDatabaseServiceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Services {
+    function exec($command) {
+        $parts = explode('>', $command);
+        $path = trim($parts[1] ?? '');
+        if (!is_dir(dirname($path))) {
+            mkdir(dirname($path), 0777, true);
+        }
+        file_put_contents($path, 'dump');
+    }
+    function sleep($seconds) {}
+}
+
+namespace {
+    use Devuni\Notifier\Services\NotifierDatabaseService;
+    use GuzzleHttp\Psr7\Response;
+    use Illuminate\Support\Facades\File;
+    
+    afterEach(function () {
+        Mockery::close();
+    });
+
+    beforeEach(function () {
+        putenv('BACKUP_URL=http://example.com');
+        putenv('BACKUP_CODE=code');
+    });
+
+    it('creates database backup file', function () {
+        $path = NotifierDatabaseService::createDatabaseBackup();
+
+        expect(File::exists($path))->toBeTrue();
+    });
+
+    it('sends database backup successfully', function () {
+        $path = NotifierDatabaseService::createDatabaseBackup();
+
+        $client = Mockery::mock('overload:GuzzleHttp\\Client');
+        $client->shouldReceive('post')->andReturn(new Response(200));
+
+        NotifierDatabaseService::sendDatabaseBackup($path);
+
+        expect(File::exists($path))->toBeFalse();
+    });
+
+    it('keeps file when sending database backup fails', function () {
+        $path = NotifierDatabaseService::createDatabaseBackup();
+
+        $client = Mockery::mock('overload:GuzzleHttp\\Client');
+        $client->shouldReceive('post')->andThrow(new \Exception('fail'));
+
+        NotifierDatabaseService::sendDatabaseBackup($path);
+
+        expect(File::exists($path))->toBeTrue();
+    });
+}

--- a/tests/Unit/NotifierServiceProviderTest.php
+++ b/tests/Unit/NotifierServiceProviderTest.php
@@ -12,6 +12,5 @@ it('loads the service provider', function () {
 });
 
 it('can load package configuration', function () {
-    // This test will pass once the config is published
-    expect(true)->toBeTrue();
+    expect(config('notifier.backup_zip_password'))->toBe(env('BACKUP_ZIP_PASSWORD', 'secret123'));
 });

--- a/tests/Unit/NotifierStorageServiceTest.php
+++ b/tests/Unit/NotifierStorageServiceTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Devuni\Notifier\Services\NotifierStorageService;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\File;
+
+describe('NotifierStorageService', function () {
+    beforeEach(function () {
+        putenv('BACKUP_URL=http://example.com');
+        putenv('BACKUP_CODE=code');
+        File::ensureDirectoryExists(storage_path('app/public'));
+        File::put(storage_path('app/public/test.txt'), 'content');
+        File::ensureDirectoryExists(storage_path('app/private'));
+        config(['notifier.backup_zip_password' => 'zip']);
+    });
+
+    afterEach(function () {
+        Mockery::close();
+        config(['notifier.backup_zip_password' => 'secret123']);
+    });
+
+    it('creates storage backup zip', function () {
+        $path = NotifierStorageService::createStorageBackup();
+
+        expect(File::exists($path))->toBeTrue();
+    });
+
+    it('sends storage backup successfully', function () {
+        $path = NotifierStorageService::createStorageBackup();
+
+        $client = Mockery::mock('overload:GuzzleHttp\\Client');
+        $client->shouldReceive('post')->andReturn(new Response(200));
+
+        NotifierStorageService::sendStorageBackup($path);
+
+        expect(File::exists($path))->toBeFalse();
+    });
+
+    it('keeps zip when sending storage backup fails', function () {
+        $path = NotifierStorageService::createStorageBackup();
+
+        $client = Mockery::mock('overload:GuzzleHttp\\Client');
+        $client->shouldReceive('post')->andThrow(new \Exception('fail'));
+
+        NotifierStorageService::sendStorageBackup($path);
+
+        expect(File::exists($path))->toBeTrue();
+    });
+});


### PR DESCRIPTION
## Summary
- exercise the notifier install command and configuration publishing in feature tests
- add unit tests for database and storage backup services with mocked clients
- verify service provider config binding

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_b_68960344082c8328b8eaba8cb4e6f8d5