### PR TITLE
Add backup token middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,16 @@ Create a database backup:
 php artisan notifier:backup
 ```
 
+### Backup HTTP Endpoint
+
+The package exposes a `/api/backup` route protected by the `auth.backup` middleware.
+Requests must supply the token defined in `config/notifier.php` via the `X-Backup-Code`
+header or a `backup_code` query parameter:
+
+```bash
+curl -H "X-Backup-Code: your-token" https://example.com/api/backup
+```
+
 ### Configuration Options
 
 ```php

--- a/app/Http/Middleware/VerifyBackupToken.php
+++ b/app/Http/Middleware/VerifyBackupToken.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Devuni\Notifier\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerifyBackupToken
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $token = $request->header('X-Backup-Code') ?? $request->query('backup_code');
+
+        if ($token !== config('notifier.backup_code')) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "type": "library",
     "autoload": {
         "psr-4": {
-            "Devuni\\Notifier\\": "src/"
+            "Devuni\\Notifier\\": "src/",
+            "Devuni\\Notifier\\Http\\": "app/Http/"
         },
         "files": [
             "src/helpers.php"

--- a/routes/notifier.php
+++ b/routes/notifier.php
@@ -1,6 +1,6 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
 use Devuni\Notifier\Controllers\NotifierController;
+use Illuminate\Support\Facades\Route;
 
-Route::get('/api/backup', NotifierController::class);
+Route::get('/api/backup', NotifierController::class)->middleware('auth.backup');

--- a/src/NotifierServiceProvider.php
+++ b/src/NotifierServiceProvider.php
@@ -3,8 +3,10 @@
 namespace Devuni\Notifier;
 
 use Devuni\Notifier\Commands\NotifierDatabaseBackupCommand;
-use Devuni\Notifier\Commands\NotifierStorageBackupCommand;
 use Devuni\Notifier\Commands\NotifierInstallCommand;
+use Devuni\Notifier\Commands\NotifierStorageBackupCommand;
+use Devuni\Notifier\Http\Middleware\VerifyBackupToken;
+use Illuminate\Routing\Router;
 use Illuminate\Support\ServiceProvider;
 
 class NotifierServiceProvider extends ServiceProvider
@@ -16,6 +18,8 @@ class NotifierServiceProvider extends ServiceProvider
         ], 'config');
 
         $this->loadRoutesFrom(__DIR__.'/../routes/notifier.php');
+
+        $this->app->make(Router::class)->aliasMiddleware('auth.backup', VerifyBackupToken::class);
     }
 
     public function register(): void


### PR DESCRIPTION
## Summary
- secure `/api/backup` route with `auth.backup` middleware
- add `VerifyBackupToken` middleware and register alias
- document how to call authenticated backup endpoint

## Testing
- `vendor/bin/pint`
- `vendor/bin/phpstan analyse src app --memory-limit=512M`
- `vendor/bin/pest`


------
https://chatgpt.com/codex/tasks/task_b_689603434db88328b057a96a05902d7f