### PR TITLE
Ensure database backups use private storage path

### DIFF
--- a/src/Services/NotifierDatabaseService.php
+++ b/src/Services/NotifierDatabaseService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Devuni\Notifier\Services;
 
 use Throwable;
@@ -8,17 +10,18 @@ use GuzzleHttp\Client;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\File;
 use Symfony\Component\Process\Process;
-use Illuminate\Support\Facades\Storage;
 
 class NotifierDatabaseService
 {
-    public static function createDatabaseBackup()
+    public static function createDatabaseBackup(): string
     {
         Log::channel('backup')->info('⚙️ STARTING NEW BACKUP ⚙️');
 
+        $backupDirectory = storage_path('app/private');
+        File::ensureDirectoryExists($backupDirectory);
+
         $filename = 'backup-'.Carbon::now()->format('Y-m-d').'.sql';
-        Storage::disk('local')->makeDirectory('backups');
-        $path = storage_path('app/private/'.$filename);
+        $path = $backupDirectory.'/'.$filename;
 
         Log::channel('backup')->info('➡️ creating backup file');
 

--- a/src/Services/NotifierStorageService.php
+++ b/src/Services/NotifierStorageService.php
@@ -1,12 +1,13 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Devuni\Notifier\Services;
 
 use Carbon\Carbon;
 use GuzzleHttp\Client;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use Throwable;
@@ -14,15 +15,16 @@ use ZipArchive;
 
 class NotifierStorageService
 {
-    public static function createStorageBackup()
+    public static function createStorageBackup(): string
     {
         Log::channel('backup')->info('⚙️ STARTING NEW BACKUP ⚙️');
 
-        Storage::disk('local')->makeDirectory('backups');
+        $backupDirectory = storage_path('app/private');
+        File::ensureDirectoryExists($backupDirectory);
 
         $filename = 'backup-'.Carbon::now()->format('Y-m-d').'.zip';
 
-        $path = storage_path('app/private/'.$filename);
+        $path = $backupDirectory.'/'.$filename;
 
         $zip = new ZipArchive;
 
@@ -55,9 +57,10 @@ class NotifierStorageService
                     $filePath = $file->getRealPath();
                     $relativePath = substr($filePath, strlen($source) + 1);
 
-                    foreach($excludedFiles as $skip) {
+                    foreach ($excludedFiles as $skip) {
                         if ($relativePath === $skip || str_starts_with($relativePath, $skip.'/')) {
-                            Log::channel('backup')->info('➡️ skipping excluded file: '. $relativePath);
+                            Log::channel('backup')->info('➡️ skipping excluded file: '.$relativePath);
+
                             continue 2;
                         }
                     }


### PR DESCRIPTION
## Summary
- make database backups use `storage/app/private` and ensure the directory exists
- enable strict types and return the backup path from `createDatabaseBackup`

## Testing
- `composer test`
- `composer analyse` *(fails: At least one path must be specified to analyse.)*


------
https://chatgpt.com/codex/tasks/task_b_68aed0c99bbc8328942b4bc7c2448777