### PR TITLE
feat: finalize 2.7.0 — explicit naming convention, status_url hardening, PostgreSQL dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `devuni/notifier-package` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.7.0] - 2026-05-09
+
+### Changed
+
+-   **`ChunkedUploadService::finalizeUpload`**: The server-side `finalize` endpoint now runs reassembly + checksum + validation + storeFile in a queued job and answers the HTTP request with `202 Accepted` plus a `status_url`. The client now polls that URL every 5 seconds (up to 30 minutes total) and only returns successfully when the server reports `status: completed`. On `status: failed` it throws a `RuntimeException` carrying the server-supplied `failure_reason`.
+    -   The `Http::timeout()` on the finalize POST itself dropped from 300 s to 60 s — the long wait now happens against the lightweight status endpoint instead of holding a single PHP-FPM worker hostage during reassembly.
+    -   **Backward-compatible** — older servers that still answer with `200/201` (synchronous finalize) continue to work; the new polling path activates only on `202`.
+
+### Notes
+
+-   This release pairs with the matching server-side change in `notifier-devuni-cz` (config `uploads.max_chunk_kb`, new `processing` upload status, `GET .../uploads/{id}/status` endpoint, async `FinalizeChunkedUploadJob`). Older `notifier-package` installs against the new server still work, but they will see the 202 response treated as immediate success — the server-side dashboard remains the source of truth for whether the backup actually landed.
+
 ## [2.6.4] - 2026-05-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.7.0] - 2026-05-09
 
+### Added
+
+-   **PostgreSQL and YugabyteDB support** - the package now backs up databases via `pg_dump` (PostgreSQL) or `ysql_dump` (YugabyteDB) in addition to `mysqldump`. The right tool is auto-selected from your Laravel connection driver (`mysql`/`mariadb`/`pgsql`).
+-   **`DatabaseDumperInterface` contract** (`src/Interfaces/DatabaseDumperInterface.php`) - pluggable strategy pattern mirroring `ZipCreatorInterface`. New implementations: `MysqlDumper`, `PostgresDumper`, and a `LazyDatabaseDumper` proxy that defers driver resolution to first use (so unsupported drivers don't break container resolution for unrelated code paths).
+-   **`NOTIFIER_DATABASE_CONNECTION` config option** - override which Laravel connection to back up (defaults to `config('database.default')`).
+-   **`NOTIFIER_POSTGRES_DUMP_BINARY` config option** - force `pg_dump` or `ysql_dump` instead of auto-detection.
+-   **`NOTIFIER_POSTGRES_SCHEMA` config option** - default schema for unqualified excluded-table names on PostgreSQL/Yugabyte (defaults to `public`).
+-   `excluded_tables` config now accepts either plain table names (auto-prefixed with the database name on MySQL/MariaDB, or with `postgres_schema` on PostgreSQL) or fully qualified `schema.table` / `db.table` names (passed through as-is).
+
 ### Changed
 
 -   **`ChunkedUploadService::finalizeUpload`**: The server-side `finalize` endpoint now runs reassembly + checksum + validation + storeFile in a queued job and answers the HTTP request with `202 Accepted` plus a `status_url`. The client now polls that URL every 5 seconds (up to 30 minutes total) and only returns successfully when the server reports `status: completed`. On `status: failed` it throws a `RuntimeException` carrying the server-supplied `failure_reason`.
-    -   The `Http::timeout()` on the finalize POST itself dropped from 300 s to 60 s — the long wait now happens against the lightweight status endpoint instead of holding a single PHP-FPM worker hostage during reassembly.
-    -   **Backward-compatible** — older servers that still answer with `200/201` (synchronous finalize) continue to work; the new polling path activates only on `202`.
+    -   The `Http::timeout()` on the finalize POST itself dropped from 300 s to 60 s - the long wait now happens against the lightweight status endpoint instead of holding a single PHP-FPM worker hostage during reassembly.
+    -   **Backward-compatible** - older servers that still answer with `200/201` (synchronous finalize) continue to work; the new polling path activates only on `202`.
+-   `NotifierDatabaseService` now receives a `DatabaseDumperInterface` via constructor injection instead of running `mysqldump` inline. The dump-vs-validate-vs-encrypt flow is unchanged from `2.6.x`.
+-   `notifier:check` replaces the hard-coded "mysqldump availability" check with a driver-aware "database dump tool" check that validates the right binary for your configured connection.
+-   **BREAKING - naming convention for interfaces, traits, and enums.** All package interfaces and traits now carry an explicit type suffix and live in type-named namespaces (`Interfaces\`, `Traits\`) instead of the Laravel-style `Contracts\` / `Concerns\`, enums consistently use the `Enum` suffix, and the `Support\` utility namespace was folded into `Services\`:
+    -   `Devuni\Notifier\Contracts\ZipCreator` → `Devuni\Notifier\Interfaces\ZipCreatorInterface`
+    -   `Devuni\Notifier\Contracts\DatabaseDumper` → `Devuni\Notifier\Interfaces\DatabaseDumperInterface`
+    -   `Devuni\Notifier\Concerns\ChecksNotifierEnvironment` → `Devuni\Notifier\Traits\ChecksNotifierEnvironmentTrait`
+    -   `Devuni\Notifier\Concerns\DisplayHelper` → `Devuni\Notifier\Traits\DisplayHelperTrait`
+    -   `Devuni\Notifier\Enums\Theme` → `Devuni\Notifier\Enums\ThemeEnum` (the `Enums\` namespace is unchanged; only the missing `Enum` suffix was added, matching the existing `BackupTypeEnum`)
+    -   `Devuni\Notifier\Support\NotifierLogger` → `Devuni\Notifier\Services\NotifierLoggerService` (the `Support\` namespace is removed; the logger is a container-bound service, so it now follows the `Services\*Service` convention)
+    -   Concrete strategy classes (`CliZipCreator`, `PhpZipCreator`, `MysqlDumper`, `PostgresDumper`, `LazyDatabaseDumper`) keep their names. Container bindings now key off the renamed FQCNs, so consumers that resolve services from the container are unaffected — only code that references the old FQCNs directly needs its imports updated.
+
+### Security
+
+-   **`ChunkedUploadService` finalize polling now validates `status_url` before attaching the token.** The async polling path attaches the long-lived `backup_code` secret (`X-Notifier-Token`) to the URL the server returns in the `202` response. The client now rejects any `status_url` that is not HTTPS or whose host/port does not match the configured `backup_url` origin, and disables redirect-following on the status GET (`allow_redirects => false`). This restores the package's HTTPS-only-in-transit invariant for the new poll requests and prevents a tampered/misconfigured finalize response from redirecting the secret to a cleartext or attacker-controlled host.
 
 ### Notes
 
--   This release pairs with the matching server-side change in `notifier-devuni-cz` (config `uploads.max_chunk_kb`, new `processing` upload status, `GET .../uploads/{id}/status` endpoint, async `FinalizeChunkedUploadJob`). Older `notifier-package` installs against the new server still work, but they will see the 202 response treated as immediate success — the server-side dashboard remains the source of truth for whether the backup actually landed.
+-   The finalize polling change pairs with the matching server-side change in `notifier-devuni-cz` (config `uploads.max_chunk_kb`, new `processing` upload status, `GET .../uploads/{id}/status` endpoint, async `FinalizeChunkedUploadJob`). Older `notifier-package` installs against the new server still work, but they will see the 202 response treated as immediate success - the server-side dashboard remains the source of truth for whether the backup actually landed.
+
+### Migration
+
+No code changes required for existing MySQL/MariaDB users - DB behavior is identical and the default Laravel connection is still used automatically. To switch a project to PostgreSQL or YugabyteDB, point `config/database.php` at the new connection and (if it's not the default) set `NOTIFIER_DATABASE_CONNECTION`.
+
+If your project references the package's interfaces or traits directly (e.g. a custom `ZipCreatorInterface` implementation, or a command that `use`s the display/environment traits), update the imports to the new `Devuni\Notifier\Interfaces\*Interface` / `Devuni\Notifier\Traits\*Trait` names. Code that only resolves services from the Laravel container needs no change.
 
 ## [2.6.4] - 2026-05-08
 
@@ -35,13 +64,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Error responses for failed backups now include `error_id` field (UUID) instead of `error` field with raw exception text — full details remain available in the server logs under the same `error_id`
+-   Error responses for failed backups now include `error_id` field (UUID) instead of `error` field with raw exception text - full details remain available in the server logs under the same `error_id`
 
 ## [2.6.2] - 2026-04-06
 
 ### Fixed
 
--   Fixed `CliZipCreator` silently failing when storage directory is empty — 7z returns exit code 0 but creates no ZIP file, causing `RuntimeException`
+-   Fixed `CliZipCreator` silently failing when storage directory is empty - 7z returns exit code 0 but creates no ZIP file, causing `RuntimeException`
 -   Added `isDirectoryEmpty()` pre-check in `CliZipCreator` to detect empty source directories (respecting excluded files) before invoking 7z
 -   `NotifierStorageService` now gracefully skips backup when no files are available instead of failing the job
 -   `ProcessBackupJob` now handles empty backup path from storage service without attempting upload
@@ -50,20 +79,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Fixed empty storage backup being sent to server — added early-exit validation that skips upload when ZIP archive is empty or too small (< 100 bytes)
--   Fixed missing backup file cleanup when empty archive is detected — file is now properly deleted before early return
--   Fixed missing diagnostics in `CliZipCreator` when 7z reports success but ZIP file is not created — error now includes 7z stdout, stderr, source path, existence, and size
+-   Fixed empty storage backup being sent to server - added early-exit validation that skips upload when ZIP archive is empty or too small (< 100 bytes)
+-   Fixed missing backup file cleanup when empty archive is detected - file is now properly deleted before early return
+-   Fixed missing diagnostics in `CliZipCreator` when 7z reports success but ZIP file is not created - error now includes 7z stdout, stderr, source path, existence, and size
 -   Removed `-bso0` and `-bsp0` flags from 7z command to allow output capture for debugging
--   Added SQL dump validation in `NotifierDatabaseService` — verifies dump file exists and is non-empty before attempting ZIP encryption
--   Fixed empty error messages from server responses (`HTTP 422 —`) — `ChunkedUploadService` now parses JSON `message` and `errors` fields from server response for actionable diagnostics
+-   Added SQL dump validation in `NotifierDatabaseService` - verifies dump file exists and is non-empty before attempting ZIP encryption
+-   Fixed empty error messages from server responses (`HTTP 422 -`) - `ChunkedUploadService` now parses JSON `message` and `errors` fields from server response for actionable diagnostics
 
 ## [2.6.0] - 2026-03-25
 
 ### Changed
 
 -   Refactored all static method calls to dependency injection via Laravel service container
--   `NotifierLogger` converted from static utility to injectable singleton — all classes now receive it through constructor or method injection
--   `ZipManager` removed — ZIP strategy resolution moved into `NotifierServiceProvider::register()` as a `ZipCreator` singleton binding
+-   `NotifierLogger` converted from static utility to injectable singleton - all classes now receive it through constructor or method injection
+-   `ZipManager` removed - ZIP strategy resolution moved into `NotifierServiceProvider::register()` as a `ZipCreator` singleton binding
 -   `CliZipCreator` and `PhpZipCreator` now receive `NotifierLogger` via constructor injection
 -   `NotifierDatabaseService` and `NotifierStorageService` now receive `ZipCreator` and `NotifierLogger` via constructor injection
 -   `ChunkedUploadService` now receives `NotifierLogger` via constructor injection
@@ -73,18 +102,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
--   `ZipManager` class (`src/Services/Zip/ZipManager.php`) — logic absorbed by service provider bindings
+-   `ZipManager` class (`src/Services/Zip/ZipManager.php`) - logic absorbed by service provider bindings
 
 ## [2.5.0] - 2026-03-17
 
 ### Added
--   Laravel 13 support — all `illuminate/*` constraints now accept `^12.55.0 || ^13.0`
+-   Laravel 13 support - all `illuminate/*` constraints now accept `^12.55.0 || ^13.0`
 -   `orchestra/testbench` constraint updated to `^11.0.0 || ^12.0` for Laravel 13 test compatibility
 
 ## [2.4.2] - 2026-03-06
 
 ### Fixed
--   Fixed `notifier:install` writing deprecated env variable names (`BACKUP_CODE`, `BACKUP_URL`, `BACKUP_ZIP_PASSWORD`) — now correctly writes `NOTIFIER_BACKUP_CODE`, `NOTIFIER_URL`, `NOTIFIER_BACKUP_PASSWORD`
+-   Fixed `notifier:install` writing deprecated env variable names (`BACKUP_CODE`, `BACKUP_URL`, `BACKUP_ZIP_PASSWORD`) - now correctly writes `NOTIFIER_BACKUP_CODE`, `NOTIFIER_URL`, `NOTIFIER_BACKUP_PASSWORD`
 
 ## [2.4.1] - 2026-03-06
 
@@ -95,9 +124,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 -   `DisplayHelper` trait with gradient ASCII logo, themed badges, and reusable display utilities for all Artisan commands
--   `Theme` enum with 5 color themes (Blue, Cyan, Green, Purple, Orange) — randomly selected per command invocation
+-   `Theme` enum with 5 color themes (Blue, Cyan, Green, Purple, Orange) - randomly selected per command invocation
 -   Rector (`rector/rector`) for automated code quality improvements with PHP 8.4 rule sets
--   `laravel/prompts` for interactive install wizard — text inputs with validation and masked password entry
+-   `laravel/prompts` for interactive install wizard - text inputs with validation and masked password entry
 -   Composite composer scripts: `lint`, `lint:check`, `check` for streamlined CI/dev workflows
 -   Explicitly declared all required illuminate components (`console`, `contracts`, `http`, `queue`, `routing`) and `guzzlehttp/guzzle`
 
@@ -117,19 +146,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.3] - 2026-03-04
 
 ### Fixed
--   Queue connection config now uses dedicated `NOTIFIER_QUEUE_CONNECTION` env var instead of reading Laravel's `QUEUE_CONNECTION` — prevents unintended async dispatch on apps that have a queue driver configured but didn't opt into queued backups
+-   Queue connection config now uses dedicated `NOTIFIER_QUEUE_CONNECTION` env var instead of reading Laravel's `QUEUE_CONNECTION` - prevents unintended async dispatch on apps that have a queue driver configured but didn't opt into queued backups
 
 ## [2.3.2] - 2026-03-04
 
 ### Added
--   Queue support for backup jobs — backups can now be dispatched to a queue worker instead of running synchronously in the HTTP request
+-   Queue support for backup jobs - backups can now be dispatched to a queue worker instead of running synchronously in the HTTP request
 -   New `ProcessBackupJob` queued job with 15-minute timeout and single-attempt safety
 -   New `queue_connection` config option (`QUEUE_CONNECTION` env var, default `sync`)
 -   Queue configuration check in `notifier:check` command
 
 ### Changed
 -   Renamed environment variable references in validation output: `BACKUP_ZIP_PASSWORD` → `NOTIFIER_BACKUP_PASSWORD`, `BACKUP_CODE` → `NOTIFIER_BACKUP_CODE`, `BACKUP_URL` → `NOTIFIER_URL`
--   `ChunkedUploadService` now streams chunks via temp files instead of loading into memory — avoids memory exhaustion on large backups
+-   `ChunkedUploadService` now streams chunks via temp files instead of loading into memory - avoids memory exhaustion on large backups
 -   `NotifierDatabaseService` and `NotifierStorageService` now re-throw exceptions instead of silently logging, enabling proper error propagation in queued jobs
 -   Backup filenames now include time (`Y-m-d_H-i-s`) to avoid collisions on multiple daily backups
 
@@ -141,7 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.0] - 2026-03-03
 ### Added
 -   Chunked upload protocol to avoid Cloudflare 413 Payload Too Large errors
--   New `ChunkedUploadService` — splits backup files into 20 MB chunks and sends via 3-phase protocol (init → chunks → finalize)
+-   New `ChunkedUploadService` - splits backup files into 20 MB chunks and sends via 3-phase protocol (init → chunks → finalize)
 -   Per-chunk retry logic (3 attempts, 2s delay) for resilient uploads
 -   SHA-256 checksum verification for both individual chunks and the complete file
 -   New `chunk_size` config option (`NOTIFIER_CHUNK_SIZE` env var, default 20 MB)
@@ -161,9 +190,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--   Fixed all unit test failures caused by Mockery being used on `final` classes — replaced with `Config::set()` approach
--   Fixed `NotifierControllerTest` referencing non-existent `NotifierController` class — rewritten to test `NotifierSendBackupController` via HTTP
--   Fixed CI test hang caused by real outbound HTTP request to `httpbin.org` in `NotifierCheckCommandTest` — added `Http::fake()`
+-   Fixed all unit test failures caused by Mockery being used on `final` classes - replaced with `Config::set()` approach
+-   Fixed `NotifierControllerTest` referencing non-existent `NotifierController` class - rewritten to test `NotifierSendBackupController` via HTTP
+-   Fixed CI test hang caused by real outbound HTTP request to `httpbin.org` in `NotifierCheckCommandTest` - added `Http::fake()`
 -   Fixed `CACHE_DRIVER=array` → `CACHE_STORE=array` in `phpunit.xml` (Laravel 12 renamed the env var, causing throttle middleware to crash with missing `cache` table)
 -   Fixed stale route/method/parameter assertions across feature tests after API redesign (`GET /api/backup` → `POST /api/notifier/backup`)
 -   Fixed Pint style issues: `fully_qualified_strict_types` and `single_blank_line_at_eof`
@@ -208,25 +237,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
--   `guzzlehttp/guzzle` from `require` — package now relies on Laravel's `Http` facade; Guzzle is available transitively through `laravel/framework`
+-   `guzzlehttp/guzzle` from `require` - package now relies on Laravel's `Http` facade; Guzzle is available transitively through `laravel/framework`
 
 ## [2.1.0] - 2026-02-18
 
 ### ⚠️ BREAKING CHANGES
 
--   **Services**: `NotifierDatabaseService` and `NotifierStorageService` are no longer static — use dependency injection or `app()` to resolve
+-   **Services**: `NotifierDatabaseService` and `NotifierStorageService` are no longer static - use dependency injection or `app()` to resolve
 
 ### Added
 
 -   `ZipCreator` interface contract for pluggable ZIP archive strategies
--   `CliZipCreator` — creates ZIP archives using CLI 7z with AES-256 encryption (low memory, fast)
--   `PhpZipCreator` — creates ZIP archives using PHP ZipArchive extension (fallback)
--   `ZipManager` — auto-resolves the best available ZIP strategy
--   `ChecksNotifierEnvironment` trait — shared environment validation for backup commands
+-   `CliZipCreator` - creates ZIP archives using CLI 7z with AES-256 encryption (low memory, fast)
+-   `PhpZipCreator` - creates ZIP archives using PHP ZipArchive extension (fallback)
+-   `ZipManager` - auto-resolves the best available ZIP strategy
+-   `ChecksNotifierEnvironment` trait - shared environment validation for backup commands
 -   `zip_strategy` config option (`auto`, `cli`, `php`) with `NOTIFIER_ZIP_STRATEGY` env var
 -   `routes_enabled` and `route_prefix` config options for route customization
 -   `--single-transaction` and `--quick` flags to mysqldump for non-locking, memory-efficient dumps
--   Exit code validation for mysqldump process — throws `RuntimeException` on failure
+-   Exit code validation for mysqldump process - throws `RuntimeException` on failure
 -   `finally` block in both services for guaranteed backup file cleanup
 -   Services registered as singletons in the service container
 
@@ -446,7 +475,8 @@ NOTIFIER_LOGGING_CHANNEL=backup
 -   GitHub Actions CI/CD
 -   Documentation and examples
 
-[Unreleased]: https://github.com/devuni-cz/notifier-package/compare/v2.6.3...HEAD
+[Unreleased]: https://github.com/devuni-cz/notifier-package/compare/v2.7.0...HEAD
+[2.7.0]: https://github.com/devuni-cz/notifier-package/compare/v2.6.4...v2.7.0
 [2.6.3]: https://github.com/devuni-cz/notifier-package/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/devuni-cz/notifier-package/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/devuni-cz/notifier-package/compare/v2.6.0...v2.6.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Laravel 12](https://img.shields.io/badge/Laravel-12-FF2D20?style=flat-square&logo=laravel&logoColor=white)](https://laravel.com)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green?style=flat-square)](LICENSE.md)
 
-Encrypted database & storage backups for Laravel apps, shipped to the [Devuni Notifier](https://notifier.devuni.cz) central server. AES-256 ZIPs, chunked HTTPS upload, token auth, queue support.
+Encrypted database & storage backups for Laravel apps, shipped to the [Devuni Notifier](https://notifier.devuni.cz) central server. AES-256 ZIPs, chunked HTTPS upload, token auth, queue support. Supports **MySQL**, **MariaDB**, **PostgreSQL**, and **YugabyteDB** (via YSQL).
 
 ## How it works
 
@@ -34,7 +34,7 @@ php artisan notifier:install   # interactive .env wizard
 php artisan notifier:check     # verify setup (env, DB, 7z, mysqldump, URL)
 ```
 
-**Requirements:** PHP 8.4+, Laravel 12+, `mysqldump`, and `p7zip-full` (recommended) or PHP `zip` extension.
+**Requirements:** PHP 8.4+, Laravel 12+, the right dump tool for your DB (`mysqldump` / `mariadb-dump` for MySQL & MariaDB, `pg_dump` or `ysql_dump` for PostgreSQL & YugabyteDB), and `p7zip-full` (recommended) or PHP `zip` extension.
 
 ## Usage
 
@@ -66,7 +66,7 @@ curl -X POST https://your-app.com/api/notifier/backup \
   -d "type=backup_database"   # or backup_storage
 ```
 
-On failure the response returns an opaque `error_id` (UUID) — the full detail (stack trace, `mysqldump`/7z stderr) stays in your `backup` log channel. Grep logs for the UUID to correlate.
+On failure the response returns an opaque `error_id` (UUID) - the full detail (stack trace, `mysqldump`/7z stderr) stays in your `backup` log channel. Grep logs for the UUID to correlate.
 
 ## Configure
 
@@ -78,11 +78,25 @@ NOTIFIER_URL=https://notifier.devuni.cz/api/v1/repositories/123 # your endpoint
 NOTIFIER_BACKUP_PASSWORD=...                                    # ZIP password
 ```
 
-Optional: `NOTIFIER_LOGGING_CHANNEL`, `NOTIFIER_ROUTES_ENABLED`, `NOTIFIER_ROUTE_PREFIX`, `NOTIFIER_ZIP_STRATEGY` (`auto`/`cli`/`php`), `NOTIFIER_CHUNK_SIZE`, `NOTIFIER_QUEUE_CONNECTION`. See [`config/notifier.php`](config/notifier.php) for defaults and descriptions.
+Optional: `NOTIFIER_LOGGING_CHANNEL`, `NOTIFIER_ROUTES_ENABLED`, `NOTIFIER_ROUTE_PREFIX`, `NOTIFIER_ZIP_STRATEGY` (`auto`/`cli`/`php`), `NOTIFIER_CHUNK_SIZE`, `NOTIFIER_QUEUE_CONNECTION`, `NOTIFIER_DATABASE_CONNECTION`, `NOTIFIER_POSTGRES_DUMP_BINARY`, `NOTIFIER_POSTGRES_SCHEMA`. See [`config/notifier.php`](config/notifier.php) for defaults and descriptions.
+
+### Database engine
+
+The package auto-detects which dump tool to use from your Laravel connection driver:
+
+| Driver | Tool used | Install |
+|---|---|---|
+| `mysql`, `mariadb` | `mysqldump` | `apt install mysql-client` or `mariadb-client` |
+| `pgsql` (PostgreSQL) | `pg_dump` | `apt install postgresql-client` |
+| `pgsql` (YugabyteDB) | `ysql_dump` if installed, else `pg_dump` | [YugabyteDB tools](https://docs.yugabyte.com) |
+
+By default the package backs up your app's **default** Laravel connection (`config('database.default')`). Override with `NOTIFIER_DATABASE_CONNECTION=pgsql` if you want a different one.
+
+For PostgreSQL/Yugabyte, force a specific binary via `NOTIFIER_POSTGRES_DUMP_BINARY=ysql_dump` (or `pg_dump`). Non-`public` schemas: set `NOTIFIER_POSTGRES_SCHEMA=myschema`.
 
 ### Exclusions
 
-Arrays — edit `config/notifier.php`:
+Arrays - edit `config/notifier.php`:
 
 ```php
 'excluded_tables' => ['telescope_entries', 'sessions', 'cache', 'jobs', 'failed_jobs'],
@@ -103,12 +117,12 @@ Artisan commands always run synchronously regardless of this setting.
 
 - **At rest:** AES-256 encrypted archives with `0600` permissions, cleaned up after upload
 - **In transit:** HTTPS-only, `hash_equals` token comparison, per-chunk + full-file SHA-256 verification
-- **No leaks:** ZIP password passed via stdin (not argv — invisible to `ps` / `/proc/*/cmdline`); API errors return opaque UUIDs, not raw exception messages
-- **Report vulnerabilities:** see [security policy](../../security/policy) — don't open public issues
+- **No leaks:** ZIP password passed via stdin (not argv - invisible to `ps` / `/proc/*/cmdline`); API errors return opaque UUIDs, not raw exception messages
+- **Report vulnerabilities:** see [security policy](../../security/policy) - don't open public issues
 
 ## Links
 
-- [Changelog](CHANGELOG.md) — see what's new in each release
+- [Changelog](CHANGELOG.md) - see what's new in each release
 - [Contributing](CONTRIBUTING.md)
 - [Full config reference](config/notifier.php)
 
@@ -119,4 +133,4 @@ Artisan commands always run synchronously regardless of this setting.
 
 ## License
 
-MIT — see [LICENSE.md](LICENSE.md).
+MIT - see [LICENSE.md](LICENSE.md).

--- a/composer.json
+++ b/composer.json
@@ -12,24 +12,24 @@
     "license": "MIT",
     "require": {
         "php": "^8.4",
-        "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/console": "^12.55.0 || ^13.0",
-        "illuminate/contracts": "^12.55.0 || ^13.0",
-        "illuminate/http": "^12.55.0 || ^13.0",
-        "illuminate/queue": "^12.55.0 || ^13.0",
-        "illuminate/routing": "^12.55.0 || ^13.0",
-        "illuminate/support": "^12.55.0 || ^13.0",
-        "laravel/prompts": "^0.3.16"
+        "guzzlehttp/guzzle": "^7.11.1",
+        "illuminate/console": "^12.55.0 || ^13.14",
+        "illuminate/contracts": "^12.55.0 || ^13.14",
+        "illuminate/http": "^12.55.0 || ^13.14",
+        "illuminate/queue": "^12.55.0 || ^13.14",
+        "illuminate/routing": "^12.55.0 || ^13.14",
+        "illuminate/support": "^12.55.0 || ^13.14",
+        "laravel/prompts": "^0.3.18"
     },
     "require-dev": {
-        "laravel/pint": "^1.29.0",
-        "larastan/larastan": "^3.9.3",
+        "laravel/pint": "^1.29.1",
+        "larastan/larastan": "^3.10.0",
         "mockery/mockery": "^1.6.12",
-        "nunomaduro/collision": "^8.9.2",
+        "nunomaduro/collision": "^8.9.4",
         "orchestra/testbench": "^11.0.0 || ^12.0",
-        "pestphp/pest": "^4.4.5",
+        "pestphp/pest": "^4.7.2",
         "pestphp/pest-plugin-laravel": "^4.1.0",
-        "rector/rector": "^2.4.0"
+        "rector/rector": "^2.4.5"
     },
     "authors": [
         {

--- a/config/notifier.php
+++ b/config/notifier.php
@@ -38,11 +38,60 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Database Connection
+    |--------------------------------------------------------------------------
+    |
+    | Which Laravel database connection to back up. When null (default), the
+    | package uses your app's default connection from config('database.default').
+    |
+    | Supported drivers: mysql, mariadb, pgsql (including YugabyteDB via YSQL).
+    |
+    */
+    'database_connection' => env('NOTIFIER_DATABASE_CONNECTION'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | PostgreSQL Dump Binary
+    |--------------------------------------------------------------------------
+    |
+    | Which CLI binary to use for PostgreSQL/YugabyteDB dumps.
+    |
+    | Options:
+    | - null (default) : Auto-detect - prefers `ysql_dump` (YugabyteDB), falls
+    |                    back to `pg_dump` (standard PostgreSQL).
+    | - 'pg_dump'      : Force standard PostgreSQL client.
+    | - 'ysql_dump'    : Force YugabyteDB's ysql_dump (a pg_dump fork with
+    |                    Yugabyte-specific optimizations).
+    |
+    | Only applies when the active connection driver is `pgsql`.
+    |
+    */
+    'postgres_dump_binary' => env('NOTIFIER_POSTGRES_DUMP_BINARY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | PostgreSQL Schema
+    |--------------------------------------------------------------------------
+    |
+    | Default schema for unqualified table names in `excluded_tables` when
+    | using a PostgreSQL/YugabyteDB connection. If a table name in the list
+    | already contains a dot (e.g. "audit.events"), it is passed through
+    | as-is.
+    |
+    */
+    'postgres_schema' => env('NOTIFIER_POSTGRES_SCHEMA', 'public'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Excluded Database Tables
     |--------------------------------------------------------------------------
     |
     | Database tables that should be excluded from the database backup.
     | Useful for excluding large log tables or temporary data.
+    |
+    | Write plain table names - the package prefixes them automatically
+    | (database name for MySQL/MariaDB, `postgres_schema` for PostgreSQL).
+    | Fully qualified names containing a dot are passed through as-is.
     |
     | Examples:
     | - 'telescope_entries'      -> Laravel Telescope data
@@ -50,6 +99,7 @@ return [
     | - 'pulse_entries'          -> Laravel Pulse data
     | - 'sessions'               -> User sessions
     | - 'cache'                  -> Cache table
+    | - 'audit.events'           -> Fully qualified - uses literal "audit" schema/db
     |
     */
     'excluded_tables' => [],
@@ -110,7 +160,7 @@ return [
     | - 'cli'            : Force CLI 7z (requires p7zip-full package)
     | - 'php'            : Force PHP ZipArchive extension
     |
-    | CLI 7z is recommended for production — it uses less memory,
+    | CLI 7z is recommended for production - it uses less memory,
     | handles large files better, and runs in a separate process.
     |
     */
@@ -136,18 +186,18 @@ return [
     |
     | The queue connection used for backup jobs dispatched via the HTTP API.
     | When set to anything other than 'sync', backups are offloaded to a
-    | queue worker — avoiding PHP max_execution_time limits.
+    | queue worker - avoiding PHP max_execution_time limits.
     |
     | Supported: 'sync', 'database', 'redis', 'sqs', 'beanstalkd'
     |            (any connection defined in config/queue.php)
     |
-    | 'sync'       — runs backup synchronously in the HTTP request (default)
-    | 'database'   — dispatches to the jobs table (requires queue:table migration)
-    | 'redis'      — dispatches to Redis (requires phpredis or predis)
-    | 'sqs'        — dispatches to Amazon SQS
-    | 'beanstalkd' — dispatches to Beanstalkd
+    | 'sync'       - runs backup synchronously in the HTTP request (default)
+    | 'database'   - dispatches to the jobs table (requires queue:table migration)
+    | 'redis'      - dispatches to Redis (requires phpredis or predis)
+    | 'sqs'        - dispatches to Amazon SQS
+    | 'beanstalkd' - dispatches to Beanstalkd
     |
-    | Artisan commands are not affected — they always run synchronously.
+    | Artisan commands are not affected - they always run synchronously.
     |
     */
     'queue_connection' => env('NOTIFIER_QUEUE_CONNECTION', 'sync'),

--- a/src/Commands/NotifierCheckCommand.php
+++ b/src/Commands/NotifierCheckCommand.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Commands;
 
-use Devuni\Notifier\Concerns\DisplayHelper;
+use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
+use Devuni\Notifier\Services\Database\LazyDatabaseDumper;
+use Devuni\Notifier\Services\Database\MysqlDumper;
+use Devuni\Notifier\Services\Database\PostgresDumper;
 use Devuni\Notifier\Services\NotifierConfigService;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Devuni\Notifier\Services\Zip\CliZipCreator;
 use Devuni\Notifier\Services\Zip\PhpZipCreator;
-use Devuni\Notifier\Support\NotifierLogger;
+use Devuni\Notifier\Traits\DisplayHelperTrait;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
@@ -17,7 +21,7 @@ use Throwable;
 
 final class NotifierCheckCommand extends Command
 {
-    use DisplayHelper;
+    use DisplayHelperTrait;
 
     protected $signature = 'notifier:check';
 
@@ -25,14 +29,14 @@ final class NotifierCheckCommand extends Command
 
     private bool $hasErrors = false;
 
-    public function handle(NotifierConfigService $configService, NotifierLogger $notifierLogger): int
+    public function handle(NotifierConfigService $configService, NotifierLoggerService $notifierLogger): int
     {
         $this->displayNotifierHeader('Health Check');
 
         $this->checkEnvironmentVariables($configService);
         $this->checkDatabaseConnection();
         $this->checkStorageDirectories();
-        $this->checkMysqldumpAvailability();
+        $this->checkDatabaseDumpTool();
         $this->checkZipAvailability();
         $this->checkLoggingChannel($notifierLogger);
         $this->checkQueueConfiguration();
@@ -155,25 +159,51 @@ final class NotifierCheckCommand extends Command
     }
 
     /**
-     * Check if mysqldump is available for database backups.
+     * Check if the right dump binary is available for the configured driver.
      */
-    private function checkMysqldumpAvailability(): void
+    private function checkDatabaseDumpTool(): void
     {
-        $this->line('<fg=yellow;options=bold>🔍 Checking mysqldump availability...</>');
+        $this->line('<fg=yellow;options=bold>🔍 Checking database dump tool...</>');
 
-        $result = shell_exec('which mysqldump 2>/dev/null') ?? shell_exec('where mysqldump 2>nul');
+        $connection = config('notifier.database_connection') ?: config('database.default');
+        $driver = config("database.connections.{$connection}.driver");
 
-        if (! empty(mb_trim($result ?? ''))) {
-            $version = shell_exec('mysqldump --version 2>&1');
-            $this->line('   <fg=green>✓</> mysqldump is available');
-            if ($version) {
-                $this->line('   <fg=gray>'.mb_trim($version).'</>');
+        $this->line("   <fg=gray>Connection:</> <fg=cyan>{$connection}</> <fg=gray>(driver: {$driver})</>");
+
+        try {
+            $dumper = app(DatabaseDumperInterface::class);
+
+            // Unwrap LazyDatabaseDumper to expose the concrete implementation
+            if ($dumper instanceof LazyDatabaseDumper) {
+                $dumper = $dumper->resolve();
             }
+        } catch (Throwable $e) {
+            $this->hasErrors = true;
+            $this->line('   <fg=red>✗</> '.$e->getMessage());
+            $this->newLine();
+
+            return;
+        }
+
+        $available = match (true) {
+            $dumper instanceof MysqlDumper => MysqlDumper::isAvailable(),
+            $dumper instanceof PostgresDumper => PostgresDumper::isAvailable(),
+            default => false,
+        };
+
+        if ($available) {
+            $this->line('   <fg=green>✓</> '.$dumper->describe());
         } else {
             $this->hasErrors = true;
-            $this->line('   <fg=red>✗</> mysqldump is not available');
-            $this->line('   <fg=gray>→ Install MySQL client tools to enable database backups</>');
+            $hint = match (true) {
+                $dumper instanceof MysqlDumper => 'Install MySQL client tools (e.g. `apt install mysql-client` or `mariadb-client`)',
+                $dumper instanceof PostgresDumper => 'Install PostgreSQL client tools (`apt install postgresql-client`) or YugabyteDB tools',
+                default => 'No dump tool available for this driver',
+            };
+            $this->line('   <fg=red>✗</> Required dump binary is not available on PATH');
+            $this->line("   <fg=gray>→ {$hint}</>");
         }
+
         $this->newLine();
     }
 
@@ -200,7 +230,7 @@ final class NotifierCheckCommand extends Command
 
         if (! $cliAvailable && ! $phpAvailable) {
             $this->hasErrors = true;
-            $this->line('   <fg=red>✗</> No ZIP strategy available — storage backups will fail');
+            $this->line('   <fg=red>✗</> No ZIP strategy available - storage backups will fail');
         } else {
             $active = $cliAvailable ? 'cli (7z)' : 'php (ZipArchive)';
 
@@ -217,7 +247,7 @@ final class NotifierCheckCommand extends Command
     /**
      * Check if the preferred logging channel is configured.
      */
-    private function checkLoggingChannel(NotifierLogger $notifierLogger): void
+    private function checkLoggingChannel(NotifierLoggerService $notifierLogger): void
     {
         $this->line('<fg=yellow;options=bold>🔍 Checking logging channel...</>');
 
@@ -239,7 +269,7 @@ final class NotifierCheckCommand extends Command
         $connection = config('notifier.queue_connection', 'sync');
 
         if ($connection === 'sync') {
-            $this->line('   <fg=gray>ℹ</> Queue connection is "sync" — backups run synchronously in the HTTP request');
+            $this->line('   <fg=gray>ℹ</> Queue connection is "sync" - backups run synchronously in the HTTP request');
             $this->line('   <fg=gray>→ Set NOTIFIER_QUEUE_CONNECTION to database, redis, or another async driver to offload backups</>');
         } else {
             $this->line("   <fg=green>✓</> Backups dispatched to queue: <fg=cyan>{$connection}</>");

--- a/src/Commands/NotifierDatabaseBackupCommand.php
+++ b/src/Commands/NotifierDatabaseBackupCommand.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Commands;
 
-use Devuni\Notifier\Concerns\ChecksNotifierEnvironment;
-use Devuni\Notifier\Concerns\DisplayHelper;
 use Devuni\Notifier\Services\NotifierConfigService;
 use Devuni\Notifier\Services\NotifierDatabaseService;
+use Devuni\Notifier\Traits\ChecksNotifierEnvironmentTrait;
+use Devuni\Notifier\Traits\DisplayHelperTrait;
 use Illuminate\Console\Command;
 
 final class NotifierDatabaseBackupCommand extends Command
 {
-    use ChecksNotifierEnvironment;
-    use DisplayHelper;
+    use ChecksNotifierEnvironmentTrait;
+    use DisplayHelperTrait;
 
     protected $signature = 'notifier:database-backup';
 

--- a/src/Commands/NotifierInstallCommand.php
+++ b/src/Commands/NotifierInstallCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Commands;
 
-use Devuni\Notifier\Concerns\DisplayHelper;
+use Devuni\Notifier\Traits\DisplayHelperTrait;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 
@@ -17,7 +17,7 @@ use function Laravel\Prompts\warning;
 
 final class NotifierInstallCommand extends Command
 {
-    use DisplayHelper;
+    use DisplayHelperTrait;
 
     protected $signature = 'notifier:install {--force : Overwrites existing environment variables}';
 

--- a/src/Commands/NotifierStorageBackupCommand.php
+++ b/src/Commands/NotifierStorageBackupCommand.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Commands;
 
-use Devuni\Notifier\Concerns\ChecksNotifierEnvironment;
-use Devuni\Notifier\Concerns\DisplayHelper;
 use Devuni\Notifier\Services\NotifierConfigService;
 use Devuni\Notifier\Services\NotifierStorageService;
+use Devuni\Notifier\Traits\ChecksNotifierEnvironmentTrait;
+use Devuni\Notifier\Traits\DisplayHelperTrait;
 use Illuminate\Console\Command;
 
 final class NotifierStorageBackupCommand extends Command
 {
-    use ChecksNotifierEnvironment;
-    use DisplayHelper;
+    use ChecksNotifierEnvironmentTrait;
+    use DisplayHelperTrait;
 
     protected $signature = 'notifier:storage-backup';
 

--- a/src/Controllers/NotifierSendBackupController.php
+++ b/src/Controllers/NotifierSendBackupController.php
@@ -8,8 +8,8 @@ use Devuni\Notifier\Enums\BackupTypeEnum;
 use Devuni\Notifier\Jobs\ProcessBackupJob;
 use Devuni\Notifier\Requests\BackupRequest;
 use Devuni\Notifier\Services\NotifierDatabaseService;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Devuni\Notifier\Services\NotifierStorageService;
-use Devuni\Notifier\Support\NotifierLogger;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Str;
 use Throwable;
@@ -19,7 +19,7 @@ final class NotifierSendBackupController
     public function __construct(
         private readonly NotifierDatabaseService $databaseService,
         private readonly NotifierStorageService $storageService,
-        private readonly NotifierLogger $notifierLogger,
+        private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
     public function __invoke(BackupRequest $request): JsonResponse

--- a/src/Enums/ThemeEnum.php
+++ b/src/Enums/ThemeEnum.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Enums;
 
-enum Theme: string
+enum ThemeEnum: string
 {
     case Blue = 'blue';
     case Cyan = 'cyan';

--- a/src/Interfaces/DatabaseDumperInterface.php
+++ b/src/Interfaces/DatabaseDumperInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Interfaces;
+
+use RuntimeException;
+
+interface DatabaseDumperInterface
+{
+    /**
+     * Check if the required dump binary is available on the current system.
+     */
+    public static function isAvailable(): bool;
+
+    /**
+     * Dump the database into the given output file.
+     *
+     * Implementations are responsible for:
+     * - Building the correct CLI arguments for their database engine
+     * - Passing credentials securely (env vars, never argv)
+     * - Applying excluded tables from package config
+     * - Throwing RuntimeException on failure (with stderr included)
+     *
+     * @param  string  $outputPath  Absolute path where the SQL dump should be written.
+     *
+     * @throws RuntimeException When the dump command fails or produces no output.
+     */
+    public function dump(string $outputPath): void;
+
+    /**
+     * Human-readable name for logs and the check command.
+     *
+     * Example: "mysqldump 8.0.35" or "pg_dump (PostgreSQL) 16.1".
+     */
+    public function describe(): string;
+}

--- a/src/Interfaces/ZipCreatorInterface.php
+++ b/src/Interfaces/ZipCreatorInterface.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace Devuni\Notifier\Contracts;
+namespace Devuni\Notifier\Interfaces;
 
 use RuntimeException;
 
-interface ZipCreator
+interface ZipCreatorInterface
 {
     /**
      * Check if this strategy is available on the current system.

--- a/src/Jobs/ProcessBackupJob.php
+++ b/src/Jobs/ProcessBackupJob.php
@@ -6,8 +6,8 @@ namespace Devuni\Notifier\Jobs;
 
 use Devuni\Notifier\Enums\BackupTypeEnum;
 use Devuni\Notifier\Services\NotifierDatabaseService;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Devuni\Notifier\Services\NotifierStorageService;
-use Devuni\Notifier\Support\NotifierLogger;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -22,15 +22,8 @@ final class ProcessBackupJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    /**
-     * The number of seconds the job can run before timing out.
-     */
     public int $timeout = 900;
 
-    /**
-     * The number of times the job may be attempted.
-     * Backup files are cleaned up after each attempt, so retrying is not safe.
-     */
     public int $tries = 1;
 
     public function __construct(
@@ -40,7 +33,7 @@ final class ProcessBackupJob implements ShouldQueue
     public function handle(
         NotifierDatabaseService $databaseService,
         NotifierStorageService $storageService,
-        NotifierLogger $notifierLogger,
+        NotifierLoggerService $notifierLogger,
     ): void {
         $logger = $notifierLogger->get();
         $startTime = microtime(true);
@@ -64,8 +57,7 @@ final class ProcessBackupJob implements ShouldQueue
 
     public function failed(Throwable $exception): void
     {
-        // failed() is called by the framework — resolve logger from container
-        $notifierLogger = app(NotifierLogger::class);
+        $notifierLogger = app(NotifierLoggerService::class);
         $notifierLogger->get()->error('❌ backup job failed', [
             'backup_type' => $this->backupType->value,
             'error' => $exception->getMessage(),

--- a/src/NotifierServiceProvider.php
+++ b/src/NotifierServiceProvider.php
@@ -8,14 +8,17 @@ use Devuni\Notifier\Commands\NotifierCheckCommand;
 use Devuni\Notifier\Commands\NotifierDatabaseBackupCommand;
 use Devuni\Notifier\Commands\NotifierInstallCommand;
 use Devuni\Notifier\Commands\NotifierStorageBackupCommand;
-use Devuni\Notifier\Contracts\ZipCreator;
+use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
+use Devuni\Notifier\Interfaces\ZipCreatorInterface;
 use Devuni\Notifier\Services\ChunkedUploadService;
+use Devuni\Notifier\Services\Database\MysqlDumper;
+use Devuni\Notifier\Services\Database\PostgresDumper;
 use Devuni\Notifier\Services\NotifierConfigService;
 use Devuni\Notifier\Services\NotifierDatabaseService;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Devuni\Notifier\Services\NotifierStorageService;
 use Devuni\Notifier\Services\Zip\CliZipCreator;
 use Devuni\Notifier\Services\Zip\PhpZipCreator;
-use Devuni\Notifier\Support\NotifierLogger;
 use Illuminate\Support\ServiceProvider;
 use RuntimeException;
 
@@ -35,9 +38,16 @@ final class NotifierServiceProvider extends ServiceProvider
         $this->app->singleton(NotifierDatabaseService::class);
         $this->app->singleton(NotifierStorageService::class);
 
-        $this->app->singleton(ZipCreator::class, function ($app): ZipCreator {
+        // Bind lazily: the actual dumper is resolved on first use, so unsupported
+        // drivers (e.g. sqlite in test envs) don't blow up at container resolution
+        // time for code paths that don't actually dump the database.
+        $this->app->singleton(DatabaseDumperInterface::class, fn ($app): DatabaseDumperInterface => new Services\Database\LazyDatabaseDumper(
+            fn (): DatabaseDumperInterface => self::resolveDumper($app),
+        ));
+
+        $this->app->singleton(ZipCreatorInterface::class, function ($app): ZipCreatorInterface {
             $strategy = config('notifier.zip_strategy', 'auto');
-            $logger = $app->make(NotifierLogger::class);
+            $logger = $app->make(NotifierLoggerService::class);
 
             return match ($strategy) {
                 'cli' => CliZipCreator::isAvailable()
@@ -54,10 +64,10 @@ final class NotifierServiceProvider extends ServiceProvider
             };
         });
 
-        $this->app->singleton(NotifierLogger::class, function (): NotifierLogger {
+        $this->app->singleton(NotifierLoggerService::class, function (): NotifierLoggerService {
             $preferredChannel = config('notifier.logging_channel', 'backup');
 
-            return new NotifierLogger($preferredChannel);
+            return new NotifierLoggerService($preferredChannel);
         });
     }
 
@@ -79,5 +89,38 @@ final class NotifierServiceProvider extends ServiceProvider
         if (config('notifier.routes_enabled', true)) {
             $this->loadRoutesFrom(self::basePath('/routes/web.php'));
         }
+    }
+
+    /**
+     * Resolve the concrete DatabaseDumperInterface implementation for the currently configured connection.
+     *
+     * @throws RuntimeException When the connection or driver is unsupported.
+     */
+    private static function resolveDumper(\Illuminate\Contracts\Foundation\Application $app): DatabaseDumperInterface
+    {
+        $logger = $app->make(NotifierLoggerService::class);
+
+        $connection = config('notifier.database_connection') ?: config('database.default');
+
+        if (empty($connection)) {
+            throw new RuntimeException(
+                'No database connection configured. Set NOTIFIER_DATABASE_CONNECTION or '
+                .'configure a default Laravel database connection.'
+            );
+        }
+
+        $driver = config("database.connections.{$connection}.driver");
+
+        return match ($driver) {
+            'mysql', 'mariadb' => new MysqlDumper($connection, $logger),
+            'pgsql' => new PostgresDumper($connection, $logger),
+            null => throw new RuntimeException(
+                "Database connection '{$connection}' is not configured in config/database.php."
+            ),
+            default => throw new RuntimeException(
+                "Unsupported database driver '{$driver}' for connection '{$connection}'. "
+                .'Supported drivers: mysql, mariadb, pgsql.'
+            ),
+        };
     }
 }

--- a/src/Services/ChunkedUploadService.php
+++ b/src/Services/ChunkedUploadService.php
@@ -217,7 +217,7 @@ final class ChunkedUploadService
 
     private function finalizeUpload(string $baseUrl, string $token, string $uploadId): void
     {
-        $response = Http::timeout(300)
+        $response = Http::timeout(60)
             ->withHeaders(['X-Notifier-Token' => $token])
             ->post(mb_rtrim($baseUrl, '/').'/uploads/'.$uploadId.'/finalize');
 
@@ -226,6 +226,94 @@ final class ChunkedUploadService
                 'Failed to finalize upload: HTTP '.$response->status().' — '.$this->formatErrorResponse($response)
             );
         }
+
+        // Async path (server v3+ returns 202 + status_url) — poll until terminal.
+        // Sync path (older server returns 200/201 with the result inline) — done.
+        if ($response->status() === 202) {
+            $statusUrl = $response->json('status_url');
+
+            if (! is_string($statusUrl) || $statusUrl === '') {
+                throw new RuntimeException('Server returned 202 without status_url');
+            }
+
+            $this->waitForCompletion($statusUrl, $token, $uploadId);
+        }
+    }
+
+    /**
+     * Poll the status endpoint until the upload reaches a terminal state.
+     * Throws on `failed` (with the server-supplied reason) or on timeout.
+     */
+    private function waitForCompletion(
+        string $statusUrl,
+        string $token,
+        string $uploadId,
+        int $maxWaitSeconds = 1800,
+        int $pollIntervalSeconds = 5,
+    ): void {
+        $logger = $this->notifierLogger->get();
+        $deadline = time() + $maxWaitSeconds;
+        $consecutiveErrors = 0;
+
+        while (time() < $deadline) {
+            sleep($pollIntervalSeconds);
+
+            try {
+                $response = Http::timeout(30)
+                    ->withHeaders(['X-Notifier-Token' => $token])
+                    ->get($statusUrl);
+            } catch (Throwable $e) {
+                $consecutiveErrors++;
+                $logger->warning("⚠️ status poll failed (attempt {$consecutiveErrors})", [
+                    'upload_id' => $uploadId,
+                    'error' => $e->getMessage(),
+                ]);
+
+                if ($consecutiveErrors >= 5) {
+                    throw new RuntimeException(
+                        "Status polling failed {$consecutiveErrors} times in a row: ".$e->getMessage(),
+                    );
+                }
+
+                continue;
+            }
+
+            if (! $response->successful()) {
+                $consecutiveErrors++;
+
+                if ($consecutiveErrors >= 5) {
+                    throw new RuntimeException(
+                        'Status polling kept returning HTTP '.$response->status().' — '.$this->formatErrorResponse($response),
+                    );
+                }
+
+                continue;
+            }
+
+            $consecutiveErrors = 0;
+
+            $status = $response->json('status');
+            $isTerminal = (bool) $response->json('is_terminal');
+
+            $logger->info("➡️ upload status: {$status}", [
+                'upload_id' => $uploadId,
+            ]);
+
+            if (! $isTerminal) {
+                continue;
+            }
+
+            if ($status === 'completed') {
+                return;
+            }
+
+            $reason = $response->json('failure_reason') ?: 'unknown';
+            throw new RuntimeException("Backup upload failed on server: {$reason}");
+        }
+
+        throw new RuntimeException(
+            "Backup upload did not finalize within {$maxWaitSeconds}s — server may still be processing it. Check the dashboard.",
+        );
     }
 
     /**

--- a/src/Services/ChunkedUploadService.php
+++ b/src/Services/ChunkedUploadService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Services;
 
-use Devuni\Notifier\Support\NotifierLogger;
 use GuzzleHttp\Promise\PromiseInterface;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\Http;
@@ -14,7 +13,7 @@ use Throwable;
 final class ChunkedUploadService
 {
     public function __construct(
-        private readonly NotifierLogger $notifierLogger,
+        private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
     /**
@@ -132,7 +131,7 @@ final class ChunkedUploadService
 
         if (! $response->successful()) {
             throw new RuntimeException(
-                'Failed to initialize upload: HTTP '.$response->status().' — '.$this->formatErrorResponse($response)
+                'Failed to initialize upload: HTTP '.$response->status().' - '.$this->formatErrorResponse($response)
             );
         }
 
@@ -183,7 +182,7 @@ final class ChunkedUploadService
                     return;
                 }
 
-                // Retry 429 (rate limited) — it's transient, not a client mistake
+                // Retry 429 (rate limited) - it's transient, not a client mistake
                 if ($response->status() === 429) {
                     $lastException = new RuntimeException(
                         "Chunk {$chunkNumber} rate limited: HTTP 429"
@@ -191,11 +190,11 @@ final class ChunkedUploadService
                 } elseif ($response->status() >= 400 && $response->status() < 500) {
                     // Don't retry other 4xx errors (client mistakes)
                     throw new RuntimeException(
-                        "Chunk {$chunkNumber} rejected: HTTP ".$response->status().' — '.$this->formatErrorResponse($response)
+                        "Chunk {$chunkNumber} rejected: HTTP ".$response->status().' - '.$this->formatErrorResponse($response)
                     );
                 } else {
                     $lastException = new RuntimeException(
-                        "Chunk {$chunkNumber} failed: HTTP ".$response->status().' — '.$this->formatErrorResponse($response)
+                        "Chunk {$chunkNumber} failed: HTTP ".$response->status().' - '.$this->formatErrorResponse($response)
                     );
                 }
             } catch (RuntimeException $e) {
@@ -223,18 +222,23 @@ final class ChunkedUploadService
 
         if (! $response->successful()) {
             throw new RuntimeException(
-                'Failed to finalize upload: HTTP '.$response->status().' — '.$this->formatErrorResponse($response)
+                'Failed to finalize upload: HTTP '.$response->status().' - '.$this->formatErrorResponse($response)
             );
         }
 
-        // Async path (server v3+ returns 202 + status_url) — poll until terminal.
-        // Sync path (older server returns 200/201 with the result inline) — done.
+        // Async path (server v3+ returns 202 + status_url) - poll until terminal.
+        // Sync path (older server returns 200/201 with the result inline) - done.
         if ($response->status() === 202) {
             $statusUrl = $response->json('status_url');
 
             if (! is_string($statusUrl) || $statusUrl === '') {
                 throw new RuntimeException('Server returned 202 without status_url');
             }
+
+            // The secret token is about to be attached to status_url. Never send it
+            // anywhere but the configured, HTTPS backup origin - the rest of the
+            // package enforces the same HTTPS-only invariant (see upload()).
+            $this->assertTrustedStatusUrl($statusUrl, $baseUrl);
 
             $this->waitForCompletion($statusUrl, $token, $uploadId);
         }
@@ -260,6 +264,7 @@ final class ChunkedUploadService
 
             try {
                 $response = Http::timeout(30)
+                    ->withOptions(['allow_redirects' => false])
                     ->withHeaders(['X-Notifier-Token' => $token])
                     ->get($statusUrl);
             } catch (Throwable $e) {
@@ -283,7 +288,7 @@ final class ChunkedUploadService
 
                 if ($consecutiveErrors >= 5) {
                     throw new RuntimeException(
-                        'Status polling kept returning HTTP '.$response->status().' — '.$this->formatErrorResponse($response),
+                        'Status polling kept returning HTTP '.$response->status().' - '.$this->formatErrorResponse($response),
                     );
                 }
 
@@ -312,8 +317,36 @@ final class ChunkedUploadService
         }
 
         throw new RuntimeException(
-            "Backup upload did not finalize within {$maxWaitSeconds}s — server may still be processing it. Check the dashboard.",
+            "Backup upload did not finalize within {$maxWaitSeconds}s - server may still be processing it. Check the dashboard.",
         );
+    }
+
+    /**
+     * Reject a server-supplied status_url that does not share the configured
+     * backup origin. The token is a long-lived shared secret; without this guard
+     * a tampered/misconfigured finalize response could redirect it to a cleartext
+     * or attacker-controlled host (the GET also runs with redirects disabled).
+     */
+    private function assertTrustedStatusUrl(string $statusUrl, string $baseUrl): void
+    {
+        $base = parse_url($baseUrl);
+        $target = parse_url($statusUrl);
+
+        if (! is_array($target) || ($target['scheme'] ?? null) !== 'https') {
+            throw new RuntimeException('Refusing to poll non-HTTPS status_url: '.$statusUrl);
+        }
+
+        $baseHost = mb_strtolower($base['host'] ?? '');
+        $targetHost = mb_strtolower($target['host'] ?? '');
+
+        if ($targetHost === '' || $targetHost !== $baseHost) {
+            throw new RuntimeException('Refusing to poll status_url on unexpected host: '.$statusUrl);
+        }
+
+        // Treat the implicit HTTPS port (443) and an explicit :443 as equivalent.
+        if (($base['port'] ?? 443) !== ($target['port'] ?? 443)) {
+            throw new RuntimeException('Refusing to poll status_url on unexpected port: '.$statusUrl);
+        }
     }
 
     /**

--- a/src/Services/Database/LazyDatabaseDumper.php
+++ b/src/Services/Database/LazyDatabaseDumper.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Services\Database;
+
+use Closure;
+use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
+
+/**
+ * Defers dumper resolution until the first method call.
+ *
+ * The service provider binds this proxy so that container resolution doesn't
+ * eagerly fail when the configured driver is unsupported (e.g. sqlite in test
+ * environments where nothing actually calls dump()). The real driver-specific
+ * dumper is constructed on demand.
+ */
+final class LazyDatabaseDumper implements DatabaseDumperInterface
+{
+    private ?DatabaseDumperInterface $resolved = null;
+
+    /**
+     * @param  Closure(): DatabaseDumperInterface  $resolver
+     */
+    public function __construct(
+        private readonly Closure $resolver,
+    ) {}
+
+    public static function isAvailable(): bool
+    {
+        // The proxy itself is always "available"; whether the resolved dumper
+        // is depends on which driver is configured. Use describe() / dump() to
+        // surface that.
+        return true;
+    }
+
+    public function dump(string $outputPath): void
+    {
+        $this->resolve()->dump($outputPath);
+    }
+
+    public function describe(): string
+    {
+        return $this->resolve()->describe();
+    }
+
+    /**
+     * Return the underlying dumper (resolving it on first call).
+     *
+     * Useful for tests and the check command, which want to inspect the real
+     * implementation without going through a dump() call.
+     */
+    public function resolve(): DatabaseDumperInterface
+    {
+        return $this->resolved ??= ($this->resolver)();
+    }
+}

--- a/src/Services/Database/MysqlDumper.php
+++ b/src/Services/Database/MysqlDumper.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Services\Database;
+
+use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
+use Devuni\Notifier\Services\NotifierLoggerService;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+final class MysqlDumper implements DatabaseDumperInterface
+{
+    /**
+     * @param  string  $connection  Laravel database connection name (e.g. "mysql").
+     */
+    public function __construct(
+        private readonly string $connection,
+        private readonly NotifierLoggerService $notifierLogger,
+    ) {}
+
+    public static function isAvailable(): bool
+    {
+        $process = new Process(['mysqldump', '--version']);
+        $process->run();
+
+        return $process->isSuccessful();
+    }
+
+    public function dump(string $outputPath): void
+    {
+        $logger = $this->notifierLogger->get();
+
+        $config = config("database.connections.{$this->connection}");
+
+        if (! is_array($config)) {
+            throw new RuntimeException("Database connection '{$this->connection}' is not configured.");
+        }
+
+        $database = $config['database'] ?? null;
+
+        if (empty($database)) {
+            throw new RuntimeException("Database connection '{$this->connection}' has no database name configured.");
+        }
+
+        $command = [
+            'mysqldump',
+            '--no-tablespaces',
+            '--single-transaction',
+            '--quick',
+            '--user='.($config['username'] ?? ''),
+            '--port='.($config['port'] ?? 3306),
+            '--host='.($config['host'] ?? '127.0.0.1'),
+        ];
+
+        // Exclusion: user writes plain table names; we prefix with database here.
+        // Fully-qualified names (containing a dot) are passed through as-is.
+        foreach (config('notifier.excluded_tables', []) as $table) {
+            $qualified = str_contains((string) $table, '.') ? (string) $table : $database.'.'.$table;
+            $command[] = '--ignore-table='.$qualified;
+        }
+
+        $command[] = '--result-file='.$outputPath;
+        $command[] = $database;
+
+        $process = new Process($command);
+        $process->setTimeout(600);
+        // Password via env var (not argv) to keep it out of /proc/*/cmdline and `ps` output.
+        $process->setEnv(['MYSQL_PWD' => (string) ($config['password'] ?? '')]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $logger->error('❌ mysqldump failed', [
+                'exitCode' => $process->getExitCode(),
+                'error' => $process->getErrorOutput(),
+            ]);
+
+            throw new RuntimeException('Database backup failed: '.$process->getErrorOutput());
+        }
+    }
+
+    public function describe(): string
+    {
+        $process = new Process(['mysqldump', '--version']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return 'mysqldump (version unknown)';
+        }
+
+        return mb_trim($process->getOutput());
+    }
+}

--- a/src/Services/Database/PostgresDumper.php
+++ b/src/Services/Database/PostgresDumper.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Services\Database;
+
+use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
+use Devuni\Notifier\Services\NotifierLoggerService;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+use Throwable;
+
+final class PostgresDumper implements DatabaseDumperInterface
+{
+    /**
+     * @param  string  $connection  Laravel database connection name (e.g. "pgsql").
+     */
+    public function __construct(
+        private readonly string $connection,
+        private readonly NotifierLoggerService $notifierLogger,
+    ) {}
+
+    /**
+     * Available if either ysql_dump (YugabyteDB) or pg_dump (PostgreSQL) is on PATH.
+     */
+    public static function isAvailable(): bool
+    {
+        return self::binaryAvailable('ysql_dump') || self::binaryAvailable('pg_dump');
+    }
+
+    public function dump(string $outputPath): void
+    {
+        $logger = $this->notifierLogger->get();
+
+        $config = config("database.connections.{$this->connection}");
+
+        if (! is_array($config)) {
+            throw new RuntimeException("Database connection '{$this->connection}' is not configured.");
+        }
+
+        $database = $config['database'] ?? null;
+
+        if (empty($database)) {
+            throw new RuntimeException("Database connection '{$this->connection}' has no database name configured.");
+        }
+
+        $binary = $this->resolveBinary();
+        $schema = (string) config('notifier.postgres_schema', 'public');
+
+        $command = [
+            $binary,
+            '--host='.($config['host'] ?? '127.0.0.1'),
+            '--port='.($config['port'] ?? 5432),
+            '--username='.($config['username'] ?? ''),
+            '--dbname='.$database,
+            '--file='.$outputPath,
+            '--no-owner',     // dumps without ownership info - restores cleanly into a different role
+            '--no-privileges', // dumps without GRANT/REVOKE statements
+            '--no-password',  // never prompt; rely on PGPASSWORD env var
+        ];
+
+        // Exclusion: user writes plain table names; we prefix with the configured schema here.
+        // Fully-qualified names (containing a dot) are passed through as-is.
+        foreach (config('notifier.excluded_tables', []) as $table) {
+            $qualified = str_contains((string) $table, '.') ? (string) $table : $schema.'.'.$table;
+            $command[] = '--exclude-table='.$qualified;
+        }
+
+        $process = new Process($command);
+        $process->setTimeout(600);
+        // Password via PGPASSWORD env var (not argv) - same rationale as MYSQL_PWD: keeps
+        // it out of /proc/*/cmdline and `ps` output on shared hosts.
+        $process->setEnv(['PGPASSWORD' => (string) ($config['password'] ?? '')]);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            $logger->error('❌ '.$binary.' failed', [
+                'exitCode' => $process->getExitCode(),
+                'error' => $process->getErrorOutput(),
+            ]);
+
+            throw new RuntimeException('Database backup failed: '.$process->getErrorOutput());
+        }
+    }
+
+    public function describe(): string
+    {
+        $binary = $this->resolveBinary();
+        $process = new Process([$binary, '--version']);
+        $process->run();
+
+        if (! $process->isSuccessful()) {
+            return $binary.' (version unknown)';
+        }
+
+        return mb_trim($process->getOutput());
+    }
+
+    private static function binaryAvailable(string $binary): bool
+    {
+        $process = new Process([$binary, '--version']);
+
+        try {
+            $process->run();
+        } catch (Throwable) {
+            return false;
+        }
+
+        return $process->isSuccessful();
+    }
+
+    /**
+     * Resolve which Postgres-compatible dump binary to use.
+     *
+     * Resolution order:
+     * 1. Explicit config override (`notifier.postgres_dump_binary`)
+     * 2. ysql_dump if installed (YugabyteDB fork - preferred for YSQL deployments)
+     * 3. pg_dump (standard PostgreSQL)
+     *
+     * @throws RuntimeException When no compatible binary is installed.
+     */
+    private function resolveBinary(): string
+    {
+        $override = config('notifier.postgres_dump_binary');
+
+        if (! empty($override)) {
+            if (! self::binaryAvailable((string) $override)) {
+                throw new RuntimeException(
+                    "Configured postgres_dump_binary '{$override}' is not available on PATH."
+                );
+            }
+
+            return (string) $override;
+        }
+
+        if (self::binaryAvailable('ysql_dump')) {
+            return 'ysql_dump';
+        }
+
+        if (self::binaryAvailable('pg_dump')) {
+            return 'pg_dump';
+        }
+
+        throw new RuntimeException(
+            'Neither ysql_dump nor pg_dump is installed. '
+            .'Install PostgreSQL client tools (e.g. `apt install postgresql-client`) '
+            .'or YugabyteDB tools (https://docs.yugabyte.com).'
+        );
+    }
+}

--- a/src/Services/NotifierDatabaseService.php
+++ b/src/Services/NotifierDatabaseService.php
@@ -5,20 +5,20 @@ declare(strict_types=1);
 namespace Devuni\Notifier\Services;
 
 use Carbon\Carbon;
-use Devuni\Notifier\Contracts\ZipCreator;
 use Devuni\Notifier\Enums\BackupTypeEnum;
-use Devuni\Notifier\Support\NotifierLogger;
+use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
+use Devuni\Notifier\Interfaces\ZipCreatorInterface;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
-use Symfony\Component\Process\Process;
 use Throwable;
 
 final class NotifierDatabaseService
 {
     public function __construct(
         private readonly ChunkedUploadService $uploadService,
-        private readonly ZipCreator $zipCreator,
-        private readonly NotifierLogger $notifierLogger,
+        private readonly ZipCreatorInterface $zipCreator,
+        private readonly DatabaseDumperInterface $databaseDumper,
+        private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
     public function createDatabaseBackup(): string
@@ -33,47 +33,17 @@ final class NotifierDatabaseService
         $filename = 'backup-'.Carbon::now()->format('Y-m-d_H-i-s').'.sql';
         $path = $backupDirectory.'/'.$filename;
 
-        $logger->info('➡️ creating backup file');
+        $logger->info('➡️ creating backup file', [
+            'dumper' => $this->databaseDumper::class,
+        ]);
 
-        $config = config('database.connections.mysql');
-        $excludedTables = config('notifier.excluded_tables', []);
-
-        $command = [
-            'mysqldump',
-            '--no-tablespaces',
-            '--single-transaction',
-            '--quick',
-            '--user='.$config['username'],
-            '--port='.$config['port'],
-            '--host='.$config['host'],
-        ];
-
-        foreach ($excludedTables as $table) {
-            $command[] = '--ignore-table='.$config['database'].'.'.$table;
-        }
-
-        $command[] = '--result-file='.$path;
-        $command[] = $config['database'];
-
-        $process = new Process($command);
-        $process->setTimeout(600);
-        $process->setEnv(['MYSQL_PWD' => $config['password']]);
-        $process->run();
-
-        if (! $process->isSuccessful()) {
-            $logger->error('❌ mysqldump failed', [
-                'exitCode' => $process->getExitCode(),
-                'error' => $process->getErrorOutput(),
-            ]);
-
-            throw new RuntimeException('Database backup failed: '.$process->getErrorOutput());
-        }
+        $this->databaseDumper->dump($path);
 
         // Validate the SQL dump before proceeding
         if (! file_exists($path)) {
             throw new RuntimeException(
                 'SQL dump file was not created at: '.$path
-                .'. mysqldump reported success but the file does not exist.'
+                .'. Dump command reported success but the file does not exist.'
             );
         }
 
@@ -84,7 +54,7 @@ final class NotifierDatabaseService
 
             throw new RuntimeException(
                 'SQL dump file is empty at: '.$path
-                .'. The database may be empty or mysqldump produced no output.'
+                .'. The database may be empty or the dump command produced no output.'
             );
         }
 

--- a/src/Services/NotifierLoggerService.php
+++ b/src/Services/NotifierLoggerService.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Devuni\Notifier\Support;
+namespace Devuni\Notifier\Services;
 
 use Illuminate\Support\Facades\Log;
 use Psr\Log\LoggerInterface;
 
-final class NotifierLogger
+final class NotifierLoggerService
 {
     private readonly LoggerInterface $logger;
 

--- a/src/Services/NotifierStorageService.php
+++ b/src/Services/NotifierStorageService.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Devuni\Notifier\Services;
 
 use Carbon\Carbon;
-use Devuni\Notifier\Contracts\ZipCreator;
 use Devuni\Notifier\Enums\BackupTypeEnum;
-use Devuni\Notifier\Support\NotifierLogger;
+use Devuni\Notifier\Interfaces\ZipCreatorInterface;
 use Illuminate\Support\Facades\File;
 use RuntimeException;
 use Throwable;
@@ -16,8 +15,8 @@ final class NotifierStorageService
 {
     public function __construct(
         private readonly ChunkedUploadService $uploadService,
-        private readonly ZipCreator $zipCreator,
-        private readonly NotifierLogger $notifierLogger,
+        private readonly ZipCreatorInterface $zipCreator,
+        private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
     public function createStorageBackup(): string

--- a/src/Services/Zip/CliZipCreator.php
+++ b/src/Services/Zip/CliZipCreator.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Services\Zip;
 
-use Devuni\Notifier\Contracts\ZipCreator;
-use Devuni\Notifier\Support\NotifierLogger;
+use Devuni\Notifier\Interfaces\ZipCreatorInterface;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Illuminate\Support\Facades\File;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 use Symfony\Component\Process\Process;
 
-final class CliZipCreator implements ZipCreator
+final class CliZipCreator implements ZipCreatorInterface
 {
     public function __construct(
-        private readonly NotifierLogger $notifierLogger,
+        private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
     public static function isAvailable(): bool
@@ -160,7 +160,7 @@ final class CliZipCreator implements ZipCreator
 
     private function countFiles(string $zipPath, string $password): int
     {
-        // Password via stdin (single prompt for listing) — same rationale
+        // Password via stdin (single prompt for listing) - same rationale
         // as archive creation: avoid exposure via /proc/<pid>/cmdline.
         $process = new Process(['7z', 'l', '-p', $zipPath]);
         $process->setInput($password."\n");

--- a/src/Services/Zip/PhpZipCreator.php
+++ b/src/Services/Zip/PhpZipCreator.php
@@ -4,18 +4,18 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Services\Zip;
 
-use Devuni\Notifier\Contracts\ZipCreator;
-use Devuni\Notifier\Support\NotifierLogger;
+use Devuni\Notifier\Interfaces\ZipCreatorInterface;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Illuminate\Support\Facades\File;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
 use ZipArchive;
 
-final class PhpZipCreator implements ZipCreator
+final class PhpZipCreator implements ZipCreatorInterface
 {
     public function __construct(
-        private readonly NotifierLogger $notifierLogger,
+        private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
     public static function isAvailable(): bool

--- a/src/Traits/ChecksNotifierEnvironmentTrait.php
+++ b/src/Traits/ChecksNotifierEnvironmentTrait.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace Devuni\Notifier\Concerns;
+namespace Devuni\Notifier\Traits;
 
 use Devuni\Notifier\Services\NotifierConfigService;
 use Illuminate\Console\Command;
 
 /** @mixin Command */
-trait ChecksNotifierEnvironment
+trait ChecksNotifierEnvironmentTrait
 {
     private function checkMissingVariables(NotifierConfigService $configService): int
     {

--- a/src/Traits/DisplayHelperTrait.php
+++ b/src/Traits/DisplayHelperTrait.php
@@ -2,24 +2,24 @@
 
 declare(strict_types=1);
 
-namespace Devuni\Notifier\Concerns;
+namespace Devuni\Notifier\Traits;
 
 use Composer\InstalledVersions;
-use Devuni\Notifier\Enums\Theme;
+use Devuni\Notifier\Enums\ThemeEnum;
 use OutOfBoundsException;
 
 use function Laravel\Prompts\note;
 
-trait DisplayHelper
+trait DisplayHelperTrait
 {
-    protected ?Theme $theme = null;
+    protected ?ThemeEnum $theme = null;
 
-    protected function initTheme(?Theme $theme = null): void
+    protected function initTheme(?ThemeEnum $theme = null): void
     {
-        $this->theme = $theme ?? Theme::random();
+        $this->theme = $theme ?? ThemeEnum::random();
     }
 
-    protected function displayNotifierHeader(string $featureName, ?Theme $theme = null): void
+    protected function displayNotifierHeader(string $featureName, ?ThemeEnum $theme = null): void
     {
         $this->initTheme($theme);
 

--- a/tests/Feature/NotifierPackageTest.php
+++ b/tests/Feature/NotifierPackageTest.php
@@ -96,7 +96,7 @@ describe('Notifier Package Basic Integration Tests', function () {
             $exitCode = Artisan::call('notifier:install');
             // Command should complete (success or failure depends on environment setup)
             expect($exitCode)->toBeIn([0, 1]);
-        })->skip('Requires interactive input — use NotifierInstallCommandTest for install command tests');
+        })->skip('Requires interactive input - use NotifierInstallCommandTest for install command tests');
 
         it('backup commands fail with missing environment', function () {
             config(['notifier.backup_code' => '', 'notifier.backup_url' => '']);
@@ -121,7 +121,7 @@ describe('Notifier Package Basic Integration Tests', function () {
             $configService = new NotifierConfigService;
             $controller = new NotifierSendBackupController($configService, new Devuni\Notifier\Services\NotifierDatabaseService, new Devuni\Notifier\Services\NotifierStorageService);
             expect($controller)->toBeInstanceOf(NotifierSendBackupController::class);
-        })->skip('Controller requires service injection — see NotifierControllerTest');
+        })->skip('Controller requires service injection - see NotifierControllerTest');
 
         it('handles missing environment variables', function () {
             config(['notifier.backup_code' => '', 'notifier.backup_url' => '']);

--- a/tests/Unit/Commands/NotifierCheckCommandTest.php
+++ b/tests/Unit/Commands/NotifierCheckCommandTest.php
@@ -97,8 +97,8 @@ describe('NotifierCheckCommand', function () {
         });
     });
 
-    describe('mysqldump availability check', function () {
-        it('checks for mysqldump command', function () {
+    describe('database dump tool check', function () {
+        it('checks for the configured database dump tool', function () {
             config([
                 'notifier.backup_code' => 'test-code',
                 'notifier.backup_url' => 'https://test-backup.com/upload',
@@ -106,7 +106,7 @@ describe('NotifierCheckCommand', function () {
             ]);
 
             $this->artisan('notifier:check')
-                ->expectsOutputToContain('Checking mysqldump availability');
+                ->expectsOutputToContain('Checking database dump tool');
         });
     });
 

--- a/tests/Unit/Services/ChunkedUploadServiceTest.php
+++ b/tests/Unit/Services/ChunkedUploadServiceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+use Devuni\Notifier\Services\ChunkedUploadService;
+use Devuni\Notifier\Services\NotifierLoggerService;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Invoke the private status_url guard via reflection so we can test the
+ * security boundary without driving the full upload + polling loop.
+ */
+function invokeStatusUrlGuard(string $statusUrl, string $baseUrl): void
+{
+    $service = new ChunkedUploadService(new NotifierLoggerService());
+    $method = new ReflectionMethod($service, 'assertTrustedStatusUrl');
+    $method->setAccessible(true);
+    $method->invoke($service, $statusUrl, $baseUrl);
+}
+
+describe('ChunkedUploadService::assertTrustedStatusUrl', function () {
+    it('accepts a same-origin HTTPS status_url', function () {
+        invokeStatusUrlGuard(
+            'https://notifier.example.com/uploads/abc-123/status',
+            'https://notifier.example.com',
+        );
+
+        // Reaching this line means no exception was thrown.
+        expect(true)->toBeTrue();
+    });
+
+    it('treats an explicit :443 port as equivalent to the implicit HTTPS port', function () {
+        invokeStatusUrlGuard(
+            'https://notifier.example.com:443/uploads/abc-123/status',
+            'https://notifier.example.com',
+        );
+
+        expect(true)->toBeTrue();
+    });
+
+    it('rejects a cleartext http status_url', function () {
+        expect(fn () => invokeStatusUrlGuard(
+            'http://notifier.example.com/uploads/abc-123/status',
+            'https://notifier.example.com',
+        ))->toThrow(RuntimeException::class, 'Refusing to poll non-HTTPS status_url');
+    });
+
+    it('rejects a status_url on a different host', function () {
+        expect(fn () => invokeStatusUrlGuard(
+            'https://attacker.example.com/uploads/abc-123/status',
+            'https://notifier.example.com',
+        ))->toThrow(RuntimeException::class, 'Refusing to poll status_url on unexpected host');
+    });
+
+    it('rejects a look-alike subdomain suffix host', function () {
+        expect(fn () => invokeStatusUrlGuard(
+            'https://notifier.example.com.attacker.com/uploads/abc-123/status',
+            'https://notifier.example.com',
+        ))->toThrow(RuntimeException::class, 'Refusing to poll status_url on unexpected host');
+    });
+
+    it('rejects a status_url on a different port', function () {
+        expect(fn () => invokeStatusUrlGuard(
+            'https://notifier.example.com:8443/uploads/abc-123/status',
+            'https://notifier.example.com',
+        ))->toThrow(RuntimeException::class, 'Refusing to poll status_url on unexpected port');
+    });
+});
+
+describe('ChunkedUploadService finalize polling', function () {
+    it('never sends the token to a foreign status_url returned by finalize', function () {
+        config([
+            'notifier.backup_url' => 'https://notifier.example.com',
+            'notifier.backup_code' => 'super-secret-token',
+        ]);
+
+        Http::fake([
+            '*/uploads/init' => Http::response(['upload_id' => 'abc-123'], 200),
+            '*/uploads/*/chunks/*' => Http::response([], 200),
+            '*/uploads/*/finalize' => Http::response(
+                ['status_url' => 'https://attacker.example.com/poll'],
+                202,
+            ),
+        ]);
+
+        $tmpPath = tempnam(sys_get_temp_dir(), 'notifier_test_');
+        file_put_contents($tmpPath, 'backup payload');
+
+        try {
+            // The guard must fire at finalize time - before any poll/sleep happens.
+            expect(fn () => (new ChunkedUploadService(new NotifierLoggerService()))
+                ->upload($tmpPath, 'database'))
+                ->toThrow(RuntimeException::class, 'Refusing to poll status_url on unexpected host');
+
+            // The long-lived secret must never have left for the attacker host.
+            Http::assertNotSent(
+                fn ($request) => str_contains($request->url(), 'attacker.example.com'),
+            );
+        } finally {
+            @unlink($tmpPath);
+        }
+    });
+});

--- a/tests/Unit/Services/NotifierLoggerServiceTest.php
+++ b/tests/Unit/Services/NotifierLoggerServiceTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-use Devuni\Notifier\Support\NotifierLogger;
+use Devuni\Notifier\Services\NotifierLoggerService;
 use Psr\Log\LoggerInterface;
 
 it('returns a LoggerInterface instance', function (): void {
-    $notifierLogger = new NotifierLogger;
+    $notifierLogger = new NotifierLoggerService;
 
     expect($notifierLogger->get())->toBeInstanceOf(LoggerInterface::class);
 });
@@ -17,7 +17,7 @@ it('uses backup channel when it exists', function (): void {
         'path' => storage_path('logs/backup.log'),
     ]);
 
-    $notifierLogger = new NotifierLogger('backup');
+    $notifierLogger = new NotifierLoggerService('backup');
 
     expect($notifierLogger->get())->toBeInstanceOf(LoggerInterface::class);
     expect($notifierLogger->isUsingPreferredChannel())->toBeTrue();
@@ -27,7 +27,7 @@ it('falls back to default channel when configured channel does not exist', funct
     config()->set('logging.channels.backup', null);
     config()->set('logging.default', 'single');
 
-    $notifierLogger = new NotifierLogger('backup');
+    $notifierLogger = new NotifierLoggerService('backup');
 
     expect($notifierLogger->get())->toBeInstanceOf(LoggerInterface::class);
     expect($notifierLogger->isUsingPreferredChannel())->toBeFalse();
@@ -39,7 +39,7 @@ it('respects custom logging channel from config', function (): void {
         'path' => storage_path('logs/custom.log'),
     ]);
 
-    $notifierLogger = new NotifierLogger('custom_channel');
+    $notifierLogger = new NotifierLoggerService('custom_channel');
 
     expect($notifierLogger->get())->toBeInstanceOf(LoggerInterface::class);
     expect($notifierLogger->getPreferredChannel())->toBe('custom_channel');


### PR DESCRIPTION
## Summary

Finalizes the unreleased **2.7.0** line. Three intertwined workstreams (all targeting 2.7.0):

### Security
`ChunkedUploadService` now validates the server-supplied `status_url` (requires HTTPS + same host/port as `backup_url`) and disables redirect-following before attaching the `X-Notifier-Token` secret on the async finalize-polling path — restoring the package''s HTTPS-only-in-transit invariant. Adds `ChunkedUploadServiceTest`.

### Naming convention (BREAKING for code referencing the old FQCNs directly)
Explicit type naming — folder = plural type, class = type suffix:
- `Contracts/` -> `Interfaces/` (`*Interface`)
- `Concerns/` -> `Traits/` (`*Trait`)
- `Enums`: `Theme` -> `ThemeEnum`
- `Support/` folded into `Services/`: `NotifierLogger` -> `NotifierLoggerService`

Container bindings updated; code resolving services from the container is unaffected.

### Feature
PostgreSQL/YugabyteDB dumps via the `DatabaseDumperInterface` strategy (`MysqlDumper`, `PostgresDumper`, `LazyDatabaseDumper`) with a driver-aware `notifier:check`.

## Tests
All 148 tests pass (40 pre-existing skips). Pint clean.