### PR TITLE
feat: announcements (2.8.0) — pull notices, Filament auto-inject & unified NotifierApiClient

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,10 @@ NOTIFIER_URL=""
 NOTIFIER_BACKUP_PASSWORD=""
 NOTIFIER_LOGGING_CHANNEL="backup"
 
-# Announcements (opt-in). When enabled, the package pulls this site's
-# maintenance/announcement notices from {NOTIFIER_URL}/announcements for display in your dashboard.
-NOTIFIER_ANNOUNCEMENTS_ENABLED=false
+# Announcements (on by default). The package pulls this site's maintenance/announcement
+# notices from {NOTIFIER_URL}/announcements and shows them in your dashboard. Costs nothing
+# until NOTIFIER_URL is set. On Filament hosts they auto-inject into the panel.
+NOTIFIER_ANNOUNCEMENTS_ENABLED=true
 NOTIFIER_ANNOUNCEMENTS_CACHE_TTL=900
+# NOTIFIER_ANNOUNCEMENTS_FILAMENT=true                     # auto-inject banner into Filament panels
+# NOTIFIER_ANNOUNCEMENTS_FILAMENT_HOOK="panels::content.start"

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@ NOTIFIER_BACKUP_CODE=""
 NOTIFIER_URL=""
 NOTIFIER_BACKUP_PASSWORD=""
 NOTIFIER_LOGGING_CHANNEL="backup"
+
+# Announcements (opt-in). When enabled, the package pulls this site's
+# maintenance/announcement notices from {NOTIFIER_URL}/announcements for display in your dashboard.
+NOTIFIER_ANNOUNCEMENTS_ENABLED=false
+NOTIFIER_ANNOUNCEMENTS_CACHE_TTL=900

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to `devuni/notifier-package` will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.8.0] - 2026-06-09
+
+### Added
+
+-   **Announcements (opt-in).** The package can now pull this site's maintenance/announcement notices from the central server and expose them for rendering in your own dashboard — the first step toward two-way communication between the agent and the platform.
+    -   **Per-repository, secure by design.** Requests reuse the existing `NOTIFIER_URL` and `X-Notifier-Token`: `GET {NOTIFIER_URL}/announcements` (e.g. `.../api/v1/repositories/52740614/announcements`). The server returns only this site's announcements, so no other repositories are ever disclosed to the client. Redirect-following is disabled on the token-bearing request.
+    -   **`AnnouncementsService::activeAnnouncements()`** — fetches and returns this site's active announcements. Always returns an array and never throws, so a down/slow announcement server can never break the consumer's dashboard.
+    -   **`<x-notifier-announcements-notice />` Blade component** — drop it into your own dashboard to render the active announcements as notice blocks (unstyled; target the `.notifier-announcement` / `.notifier-announcement--{severity}` classes). Views are publishable via `--tag=notifier-views`.
+    -   **Caching** — successful responses are cached (`NOTIFIER_ANNOUNCEMENTS_CACHE_TTL`, default 900 s) and failures are briefly negative-cached (`NOTIFIER_ANNOUNCEMENTS_FAILURE_CACHE_TTL`, default 60 s), so the dashboard never makes a blocking HTTP request on every page load.
+    -   New config: `notifier.features.announcements` (toggle, env `NOTIFIER_ANNOUNCEMENTS_ENABLED`, default `false`) and the `notifier.announcements.*` block (`cache_ttl`, `failure_cache_ttl`, `timeout`). Backward-compatible defaults via `mergeConfigFrom` — no need to re-publish `config/notifier.php`.
+
+### Notes
+
+-   The feature is **off by default** and a backup-only install carries no extra behavior or HTTP traffic. It pairs with a matching `GET /api/v1/repositories/{id}/announcements` endpoint on `notifier-devuni-cz` (server side, separate).
+
 ## [2.7.1] - 2026-06-09
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   The feature is **on by default** but makes no HTTP call until `NOTIFIER_URL` is configured, so a backup-only install carries no extra traffic. It pairs with a matching `GET /api/v1/repositories/{id}/announcements` endpoint on `notifier-devuni-cz` (server side, separate).
 
+### Changed
+
+-   **All server communication now flows through a single `NotifierApiClient`.** The HTTPS-only enforcement, the `X-Notifier-Token` header, redirect-disabling, base-URL resolution, and JSON error formatting that were duplicated across `ChunkedUploadService` (push) and `AnnouncementsService` (pull) now live in one transport. New agent capabilities inherit these invariants and cannot accidentally omit one. Backup-upload behavior is unchanged (all existing tests pass).
+
+### Security
+
+-   **The announcements pull is now HTTPS-only, matching the backup path.** Previously `AnnouncementsService` did not enforce `https://` on `NOTIFIER_URL`, so a misconfigured `http://` URL would have sent the `X-Notifier-Token` secret over cleartext. Centralizing the transport in `NotifierApiClient` closes that gap: the token is never attached to a non-HTTPS request — the pull logs and returns nothing instead.
+
 ## [2.7.1] - 2026-06-09
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
--   **Announcements (opt-in).** The package can now pull this site's maintenance/announcement notices from the central server and expose them for rendering in your own dashboard — the first step toward two-way communication between the agent and the platform.
+-   **Announcements.** The package can now pull this site's maintenance/announcement notices from the central server and surface them in your dashboard — the first step toward two-way communication between the agent and the platform. **On by default** (costs nothing until `NOTIFIER_URL` is set — the service no-ops without a target).
     -   **Per-repository, secure by design.** Requests reuse the existing `NOTIFIER_URL` and `X-Notifier-Token`: `GET {NOTIFIER_URL}/announcements` (e.g. `.../api/v1/repositories/52740614/announcements`). The server returns only this site's announcements, so no other repositories are ever disclosed to the client. Redirect-following is disabled on the token-bearing request.
     -   **`AnnouncementsService::activeAnnouncements()`** — fetches and returns this site's active announcements. Always returns an array and never throws, so a down/slow announcement server can never break the consumer's dashboard.
+    -   **Filament auto-injection.** On hosts running Filament (v3/v4/v5), the active announcements are auto-injected as a styled banner into every panel page via a render hook — no manual placement. Configurable via `NOTIFIER_ANNOUNCEMENTS_FILAMENT_HOOK` (default `panels::content.start`) and toggleable with `NOTIFIER_ANNOUNCEMENTS_FILAMENT`. Registered only when Filament is actually installed, so other hosts are unaffected.
     -   **`<x-notifier-announcements-notice />` Blade component** — drop it into your own dashboard to render the active announcements as notice blocks (unstyled; target the `.notifier-announcement` / `.notifier-announcement--{severity}` classes). Views are publishable via `--tag=notifier-views`.
+    -   **Framework-agnostic** — Inertia/Vue/React hosts can render `AnnouncementsService::activeAnnouncements()` themselves (e.g. as a shared Inertia prop).
     -   **Caching** — successful responses are cached (`NOTIFIER_ANNOUNCEMENTS_CACHE_TTL`, default 900 s) and failures are briefly negative-cached (`NOTIFIER_ANNOUNCEMENTS_FAILURE_CACHE_TTL`, default 60 s), so the dashboard never makes a blocking HTTP request on every page load.
-    -   New config: `notifier.features.announcements` (toggle, env `NOTIFIER_ANNOUNCEMENTS_ENABLED`, default `false`) and the `notifier.announcements.*` block (`cache_ttl`, `failure_cache_ttl`, `timeout`). Backward-compatible defaults via `mergeConfigFrom` — no need to re-publish `config/notifier.php`.
+    -   New config: `notifier.features.announcements` (toggle, env `NOTIFIER_ANNOUNCEMENTS_ENABLED`, **default `true`**) and the `notifier.announcements.*` block (`cache_ttl`, `failure_cache_ttl`, `timeout`, plus `filament.enabled` / `filament.render_hook`). Backward-compatible defaults via `mergeConfigFrom` — no need to re-publish `config/notifier.php`.
 
 ### Notes
 
--   The feature is **off by default** and a backup-only install carries no extra behavior or HTTP traffic. It pairs with a matching `GET /api/v1/repositories/{id}/announcements` endpoint on `notifier-devuni-cz` (server side, separate).
+-   The feature is **on by default** but makes no HTTP call until `NOTIFIER_URL` is configured, so a backup-only install carries no extra traffic. It pairs with a matching `GET /api/v1/repositories/{id}/announcements` endpoint on `notifier-devuni-cz` (server side, separate).
 
 ## [2.7.1] - 2026-06-09
 

--- a/README.md
+++ b/README.md
@@ -68,15 +68,26 @@ curl -X POST https://your-app.com/api/notifier/backup \
 
 On failure the response returns an opaque `error_id` (UUID) - the full detail (stack trace, `mysqldump`/7z stderr) stays in your `backup` log channel. Grep logs for the UUID to correlate.
 
-### Announcements (opt-in)
+### Announcements
 
-Pull this site's maintenance/announcement notices from the central server and render them in your own dashboard. Off by default - enable with `NOTIFIER_ANNOUNCEMENTS_ENABLED=true`, then drop the component anywhere:
+Pull this site's maintenance/announcement notices from the central server and show them in your dashboard. **On by default** - it costs nothing until `NOTIFIER_URL` is set (the service no-ops without a target). Disable with `NOTIFIER_ANNOUNCEMENTS_ENABLED=false`.
+
+**Filament hosts** (the common case): when Filament is installed, the notices are **auto-injected** as a banner into every panel page via a render hook - nothing to place. Move the spot with `NOTIFIER_ANNOUNCEMENTS_FILAMENT_HOOK` (default `panels::content.start`; also `panels::body.start`, `panels::topbar.end`), or turn the auto-injection off with `NOTIFIER_ANNOUNCEMENTS_FILAMENT=false`. Works across Filament v3/v4/v5.
+
+**Blade hosts:** drop the component anywhere:
 
 ```blade
 <x-notifier-announcements-notice />
 ```
 
-Requests are **per-repository** and reuse your existing `NOTIFIER_URL` + `X-Notifier-Token` (`GET {NOTIFIER_URL}/announcements`), so the server returns only this site's announcements - no other repositories are disclosed. Responses are cached (`NOTIFIER_ANNOUNCEMENTS_CACHE_TTL`, default 900 s) so the dashboard never blocks on a live request, and any fetch failure renders nothing rather than breaking your dashboard. Customize the markup with `vendor:publish --tag="notifier-views"`, or render it yourself from `app(\Devuni\Notifier\Services\AnnouncementsService::class)->activeAnnouncements()`.
+**Inertia / Vue / React hosts:** the service is framework-agnostic - render it yourself:
+
+```php
+app(\Devuni\Notifier\Services\AnnouncementsService::class)->activeAnnouncements();
+// e.g. share as an Inertia prop, then render it in your own component.
+```
+
+Requests are **per-repository** and reuse your existing `NOTIFIER_URL` + `X-Notifier-Token` (`GET {NOTIFIER_URL}/announcements`), so the server returns only this site's announcements - no other repositories are disclosed. Responses are cached (`NOTIFIER_ANNOUNCEMENTS_CACHE_TTL`, default 900 s) so the dashboard never blocks on a live request, and any fetch failure renders nothing rather than breaking your dashboard. Customize the Blade markup with `vendor:publish --tag="notifier-views"`.
 
 ## Configure
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ curl -X POST https://your-app.com/api/notifier/backup \
 
 On failure the response returns an opaque `error_id` (UUID) - the full detail (stack trace, `mysqldump`/7z stderr) stays in your `backup` log channel. Grep logs for the UUID to correlate.
 
+### Announcements (opt-in)
+
+Pull this site's maintenance/announcement notices from the central server and render them in your own dashboard. Off by default - enable with `NOTIFIER_ANNOUNCEMENTS_ENABLED=true`, then drop the component anywhere:
+
+```blade
+<x-notifier-announcements-notice />
+```
+
+Requests are **per-repository** and reuse your existing `NOTIFIER_URL` + `X-Notifier-Token` (`GET {NOTIFIER_URL}/announcements`), so the server returns only this site's announcements - no other repositories are disclosed. Responses are cached (`NOTIFIER_ANNOUNCEMENTS_CACHE_TTL`, default 900 s) so the dashboard never blocks on a live request, and any fetch failure renders nothing rather than breaking your dashboard. Customize the markup with `vendor:publish --tag="notifier-views"`, or render it yourself from `app(\Devuni\Notifier\Services\AnnouncementsService::class)->activeAnnouncements()`.
+
 ## Configure
 
 Minimum `.env`:

--- a/config/notifier.php
+++ b/config/notifier.php
@@ -207,14 +207,15 @@ return [
     | Feature Toggles
     |--------------------------------------------------------------------------
     |
-    | Opt-in switches for agent features beyond backups. A backup-only install
-    | can leave these off and carries no extra behavior or HTTP traffic.
+    | Switches for agent features beyond backups. Announcements are ON by default
+    | but cost nothing until NOTIFIER_URL is configured - the service no-ops and
+    | makes no HTTP call without a target, so a backup-only install is unaffected.
     |
     */
     'features' => [
-        // Pull this site's maintenance/announcement announcements from the central
+        // Pull this site's maintenance/announcement notices from the central
         // server and expose them for rendering in your own dashboard.
-        'announcements' => env('NOTIFIER_ANNOUNCEMENTS_ENABLED', false),
+        'announcements' => env('NOTIFIER_ANNOUNCEMENTS_ENABLED', true),
     ],
 
     /*
@@ -238,5 +239,21 @@ return [
 
         // HTTP timeout (seconds) for the announcements request.
         'timeout' => (int) env('NOTIFIER_ANNOUNCEMENTS_TIMEOUT', 5),
+
+        /*
+        | Filament integration. When the host app uses Filament, the package can
+        | auto-inject the active announcements as a banner into every panel page
+        | via a Filament render hook - no manual placement needed. Registered only
+        | when Filament is actually installed, so non-Filament hosts are unaffected.
+        */
+        'filament' => [
+            // Auto-inject the announcements banner into Filament panels.
+            'enabled' => env('NOTIFIER_ANNOUNCEMENTS_FILAMENT', true),
+
+            // Which Filament render hook to inject at. A plain string keeps this
+            // version-agnostic across Filament v3/v4/v5. Default: top of the page
+            // content. Alternatives: 'panels::body.start', 'panels::topbar.end'.
+            'render_hook' => env('NOTIFIER_ANNOUNCEMENTS_FILAMENT_HOOK', 'panels::content.start'),
+        ],
     ],
 ];

--- a/config/notifier.php
+++ b/config/notifier.php
@@ -201,4 +201,42 @@ return [
     |
     */
     'queue_connection' => env('NOTIFIER_QUEUE_CONNECTION', 'sync'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Feature Toggles
+    |--------------------------------------------------------------------------
+    |
+    | Opt-in switches for agent features beyond backups. A backup-only install
+    | can leave these off and carries no extra behavior or HTTP traffic.
+    |
+    */
+    'features' => [
+        // Pull this site's maintenance/announcement announcements from the central
+        // server and expose them for rendering in your own dashboard.
+        'announcements' => env('NOTIFIER_ANNOUNCEMENTS_ENABLED', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Announcements
+    |--------------------------------------------------------------------------
+    |
+    | When the `announcements` feature is enabled, the package fetches this site's
+    | active announcements from `{NOTIFIER_URL}/announcements` (per-repository, authenticated
+    | with the same X-Notifier-Token). Responses are cached so the consumer
+    | dashboard never makes a blocking request on every page load.
+    |
+    */
+    'announcements' => [
+        // Seconds a successful response is cached. Default 15 minutes.
+        'cache_ttl' => (int) env('NOTIFIER_ANNOUNCEMENTS_CACHE_TTL', 900),
+
+        // Seconds to negative-cache an empty result after a fetch failure, so a
+        // down/slow server doesn't make every dashboard load pay the timeout.
+        'failure_cache_ttl' => (int) env('NOTIFIER_ANNOUNCEMENTS_FAILURE_CACHE_TTL', 60),
+
+        // HTTP timeout (seconds) for the announcements request.
+        'timeout' => (int) env('NOTIFIER_ANNOUNCEMENTS_TIMEOUT', 5),
+    ],
 ];

--- a/resources/views/components/announcements-notice.blade.php
+++ b/resources/views/components/announcements-notice.blade.php
@@ -1,0 +1,12 @@
+@if (! empty($announcements))
+    <div class="notifier-announcements">
+        @foreach ($announcements as $announcement)
+            @php($content = $announcement['content'] ?? null)
+            @if (! empty($content))
+                <div class="notifier-announcement notifier-announcement--{{ $announcement['severity'] ?? 'info' }}" role="status">
+                    {{ $content }}
+                </div>
+            @endif
+        @endforeach
+    </div>
+@endif

--- a/resources/views/filament/announcements.blade.php
+++ b/resources/views/filament/announcements.blade.php
@@ -1,0 +1,32 @@
+{{-- Auto-injected into Filament panels via a render hook (see NotifierServiceProvider). --}}
+{{-- Self-contained styles + .notifier-* classes so nothing depends on the host's Tailwind build. --}}
+@if (! empty($announcements))
+    <style>
+        .notifier-announcements { display: flex; flex-direction: column; gap: .5rem; padding: 1rem 1.5rem 0; }
+        .notifier-announcement { border-radius: .5rem; border: 1px solid transparent; padding: .625rem 1rem; font-size: .875rem; line-height: 1.25rem; font-weight: 500; }
+        .notifier-announcement--critical { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
+        .notifier-announcement--high     { background: #fff7ed; color: #9a3412; border-color: #fed7aa; }
+        .notifier-announcement--medium   { background: #fffbeb; color: #92400e; border-color: #fde68a; }
+        .notifier-announcement--low      { background: #f0f9ff; color: #075985; border-color: #bae6fd; }
+        .notifier-announcement--info     { background: #f9fafb; color: #374151; border-color: #e5e7eb; }
+        .dark .notifier-announcement--critical { background: rgba(248,113,113,.10); color: #fca5a5; border-color: rgba(248,113,113,.30); }
+        .dark .notifier-announcement--high     { background: rgba(251,146,60,.10);  color: #fdba74; border-color: rgba(251,146,60,.30); }
+        .dark .notifier-announcement--medium   { background: rgba(251,191,36,.10);  color: #fcd34d; border-color: rgba(251,191,36,.30); }
+        .dark .notifier-announcement--low      { background: rgba(56,189,248,.10);  color: #7dd3fc; border-color: rgba(56,189,248,.30); }
+        .dark .notifier-announcement--info     { background: rgba(255,255,255,.05); color: #d1d5db; border-color: rgba(255,255,255,.10); }
+    </style>
+
+    <div class="notifier-announcements">
+        @foreach ($announcements as $announcement)
+            @php($content = $announcement['content'] ?? null)
+            @if (! empty($content))
+                <div
+                    role="status"
+                    class="notifier-announcement notifier-announcement--{{ $announcement['severity'] ?? 'info' }}"
+                >
+                    {{ $content }}
+                </div>
+            @endif
+        @endforeach
+    </div>
+@endif

--- a/src/NotifierServiceProvider.php
+++ b/src/NotifierServiceProvider.php
@@ -22,6 +22,7 @@ use Devuni\Notifier\Services\NotifierStorageService;
 use Devuni\Notifier\Services\Zip\CliZipCreator;
 use Devuni\Notifier\Services\Zip\PhpZipCreator;
 use Devuni\Notifier\View\Components\AnnouncementsNotice;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use RuntimeException;
 
@@ -168,7 +169,7 @@ final class NotifierServiceProvider extends ServiceProvider
 
         \Filament\Support\Facades\FilamentView::registerRenderHook(
             (string) config('notifier.announcements.filament.render_hook', 'panels::content.start'),
-            fn (): string => view('notifier::filament.announcements', [
+            fn (): string => View::make('notifier::filament.announcements', [
                 'announcements' => $this->app->make(AnnouncementsService::class)->activeAnnouncements(),
             ])->render(),
         );

--- a/src/NotifierServiceProvider.php
+++ b/src/NotifierServiceProvider.php
@@ -14,6 +14,7 @@ use Devuni\Notifier\Services\AnnouncementsService;
 use Devuni\Notifier\Services\ChunkedUploadService;
 use Devuni\Notifier\Services\Database\MysqlDumper;
 use Devuni\Notifier\Services\Database\PostgresDumper;
+use Devuni\Notifier\Services\NotifierApiClient;
 use Devuni\Notifier\Services\NotifierConfigService;
 use Devuni\Notifier\Services\NotifierDatabaseService;
 use Devuni\Notifier\Services\NotifierLoggerService;
@@ -35,6 +36,7 @@ final class NotifierServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(self::basePath('/config/notifier.php'), 'notifier');
 
+        $this->app->singleton(NotifierApiClient::class);
         $this->app->singleton(NotifierConfigService::class);
         $this->app->singleton(ChunkedUploadService::class);
         $this->app->singleton(NotifierDatabaseService::class);

--- a/src/NotifierServiceProvider.php
+++ b/src/NotifierServiceProvider.php
@@ -10,6 +10,7 @@ use Devuni\Notifier\Commands\NotifierInstallCommand;
 use Devuni\Notifier\Commands\NotifierStorageBackupCommand;
 use Devuni\Notifier\Interfaces\DatabaseDumperInterface;
 use Devuni\Notifier\Interfaces\ZipCreatorInterface;
+use Devuni\Notifier\Services\AnnouncementsService;
 use Devuni\Notifier\Services\ChunkedUploadService;
 use Devuni\Notifier\Services\Database\MysqlDumper;
 use Devuni\Notifier\Services\Database\PostgresDumper;
@@ -19,6 +20,7 @@ use Devuni\Notifier\Services\NotifierLoggerService;
 use Devuni\Notifier\Services\NotifierStorageService;
 use Devuni\Notifier\Services\Zip\CliZipCreator;
 use Devuni\Notifier\Services\Zip\PhpZipCreator;
+use Devuni\Notifier\View\Components\AnnouncementsNotice;
 use Illuminate\Support\ServiceProvider;
 use RuntimeException;
 
@@ -37,6 +39,7 @@ final class NotifierServiceProvider extends ServiceProvider
         $this->app->singleton(ChunkedUploadService::class);
         $this->app->singleton(NotifierDatabaseService::class);
         $this->app->singleton(NotifierStorageService::class);
+        $this->app->singleton(AnnouncementsService::class);
 
         // Bind lazily: the actual dumper is resolved on first use, so unsupported
         // drivers (e.g. sqlite in test envs) don't blow up at container resolution
@@ -78,6 +81,10 @@ final class NotifierServiceProvider extends ServiceProvider
                 self::basePath('/config/notifier.php') => config_path('notifier.php'),
             ], 'notifier-config');
 
+            $this->publishes([
+                self::basePath('/resources/views') => resource_path('views/vendor/notifier'),
+            ], 'notifier-views');
+
             $this->commands([
                 NotifierCheckCommand::class,
                 NotifierDatabaseBackupCommand::class,
@@ -85,6 +92,14 @@ final class NotifierServiceProvider extends ServiceProvider
                 NotifierStorageBackupCommand::class,
             ]);
         }
+
+        // The <x-notifier-announcements-notice /> component is always available; the
+        // AnnouncementsService itself gates behavior on the `features.announcements` flag, so a
+        // disabled install renders nothing and makes no HTTP call.
+        $this->loadViewsFrom(self::basePath('/resources/views'), 'notifier');
+        $this->loadViewComponentsAs('notifier', [
+            AnnouncementsNotice::class,
+        ]);
 
         if (config('notifier.routes_enabled', true)) {
             $this->loadRoutesFrom(self::basePath('/routes/web.php'));

--- a/src/NotifierServiceProvider.php
+++ b/src/NotifierServiceProvider.php
@@ -101,6 +101,8 @@ final class NotifierServiceProvider extends ServiceProvider
             AnnouncementsNotice::class,
         ]);
 
+        $this->registerFilamentAnnouncements();
+
         if (config('notifier.routes_enabled', true)) {
             $this->loadRoutesFrom(self::basePath('/routes/web.php'));
         }
@@ -137,5 +139,36 @@ final class NotifierServiceProvider extends ServiceProvider
                 .'Supported drivers: mysql, mariadb, pgsql.'
             ),
         };
+    }
+
+    /**
+     * Auto-inject the active announcements as a banner into Filament panels via a
+     * render hook. No-ops unless the announcements feature is on, the Filament
+     * integration is enabled, and Filament is actually installed in the host app -
+     * so non-Filament hosts (and the package's own tests) are never touched.
+     *
+     * The render hook is identified by a plain string, which is stable across
+     * Filament v3/v4/v5, so no Filament class is referenced at the type level.
+     */
+    private function registerFilamentAnnouncements(): void
+    {
+        if (! config('notifier.features.announcements', true)) {
+            return;
+        }
+
+        if (! config('notifier.announcements.filament.enabled', true)) {
+            return;
+        }
+
+        if (! class_exists(\Filament\Support\Facades\FilamentView::class)) {
+            return;
+        }
+
+        \Filament\Support\Facades\FilamentView::registerRenderHook(
+            (string) config('notifier.announcements.filament.render_hook', 'panels::content.start'),
+            fn (): string => view('notifier::filament.announcements', [
+                'announcements' => $this->app->make(AnnouncementsService::class)->activeAnnouncements(),
+            ])->render(),
+        );
     }
 }

--- a/src/Services/AnnouncementsService.php
+++ b/src/Services/AnnouncementsService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Devuni\Notifier\Services;
 
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
 use Throwable;
 
 /**
@@ -23,6 +22,7 @@ use Throwable;
 final class AnnouncementsService
 {
     public function __construct(
+        private readonly NotifierApiClient $api,
         private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
@@ -51,7 +51,7 @@ final class AnnouncementsService
             return $cached;
         }
 
-        return $this->fetchAndCache($baseUrl, $cacheKey);
+        return $this->fetchAndCache($cacheKey);
     }
 
     /**
@@ -78,24 +78,20 @@ final class AnnouncementsService
     /**
      * @return list<array<string, mixed>>
      */
-    private function fetchAndCache(string $baseUrl, string $cacheKey): array
+    private function fetchAndCache(string $cacheKey): array
     {
-        $token = config('notifier.backup_code');
         $timeout = (int) config('notifier.announcements.timeout', 5);
 
         try {
-            $response = Http::timeout($timeout)
-                // The shared secret rides on this request - never follow a redirect
-                // with it attached (Guzzle re-sends custom headers across redirects).
-                ->withOptions(['allow_redirects' => false])
-                ->withHeaders(['X-Notifier-Token' => (string) $token])
-                ->get(mb_rtrim($baseUrl, '/').'/announcements');
+            // All transport invariants (HTTPS-only, token, no-redirect) live in the
+            // shared client, so this pull can never leak the secret over cleartext.
+            $response = $this->api->get('/announcements', $timeout);
         } catch (Throwable $e) {
             return $this->cacheFailure($cacheKey, $e->getMessage());
         }
 
         if (! $response->successful()) {
-            return $this->cacheFailure($cacheKey, 'HTTP '.$response->status());
+            return $this->cacheFailure($cacheKey, 'HTTP '.$response->status().' - '.$this->api->formatError($response));
         }
 
         $announcements = $response->json('announcements');

--- a/src/Services/AnnouncementsService.php
+++ b/src/Services/AnnouncementsService.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * Pulls this site's active maintenance/announcement notices from the central server.
+ *
+ * The request is per-repository: it reuses the configured backup URL
+ * (`{NOTIFIER_URL}/announcements`, e.g. `.../api/v1/repositories/52740614/announcements`) and the
+ * same `X-Notifier-Token`, so the server already knows which site is asking and
+ * returns only that site's announcements - no other repositories are ever disclosed.
+ *
+ * Responses are cached so the consumer's dashboard never makes a blocking HTTP
+ * request on every page load, and failures are swallowed (returning an empty
+ * list) so a down/slow announcement server can never break the dashboard.
+ */
+final class AnnouncementsService
+{
+    public function __construct(
+        private readonly NotifierLoggerService $notifierLogger,
+    ) {}
+
+    /**
+     * Active announcements for this site. Always returns a list and never throws.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function activeAnnouncements(): array
+    {
+        if (! config('notifier.features.announcements', false)) {
+            return [];
+        }
+
+        $baseUrl = config('notifier.backup_url');
+
+        if (! is_string($baseUrl) || $baseUrl === '') {
+            return [];
+        }
+
+        $cacheKey = $this->cacheKey($baseUrl);
+        $cached = Cache::get($cacheKey);
+
+        if (is_array($cached)) {
+            /** @var list<array<string, mixed>> $cached */
+            return $cached;
+        }
+
+        return $this->fetchAndCache($baseUrl, $cacheKey);
+    }
+
+    /**
+     * The repository id this site reports as, parsed from the configured
+     * NOTIFIER_URL (`.../repositories/{id}`). Null if it can't be determined.
+     */
+    public function repositoryId(): ?string
+    {
+        $baseUrl = config('notifier.backup_url');
+
+        if (! is_string($baseUrl) || $baseUrl === '') {
+            return null;
+        }
+
+        $path = parse_url($baseUrl, PHP_URL_PATH);
+
+        if (is_string($path) && preg_match('#/repositories/([^/]+)#', $path, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function fetchAndCache(string $baseUrl, string $cacheKey): array
+    {
+        $token = config('notifier.backup_code');
+        $timeout = (int) config('notifier.announcements.timeout', 5);
+
+        try {
+            $response = Http::timeout($timeout)
+                // The shared secret rides on this request - never follow a redirect
+                // with it attached (Guzzle re-sends custom headers across redirects).
+                ->withOptions(['allow_redirects' => false])
+                ->withHeaders(['X-Notifier-Token' => (string) $token])
+                ->get(mb_rtrim($baseUrl, '/').'/announcements');
+        } catch (Throwable $e) {
+            return $this->cacheFailure($cacheKey, $e->getMessage());
+        }
+
+        if (! $response->successful()) {
+            return $this->cacheFailure($cacheKey, 'HTTP '.$response->status());
+        }
+
+        $announcements = $response->json('announcements');
+
+        $announcements = is_array($announcements) ? array_values($announcements) : [];
+
+        Cache::put($cacheKey, $announcements, (int) config('notifier.announcements.cache_ttl', 900));
+
+        /** @var list<array<string, mixed>> $announcements */
+        return $announcements;
+    }
+
+    /**
+     * Log the failure and briefly negative-cache an empty result, so a down or
+     * slow server doesn't make every dashboard page load pay the HTTP timeout.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function cacheFailure(string $cacheKey, string $reason): array
+    {
+        $this->notifierLogger->get()->warning('⚠️ failed to fetch notifier announcements', [
+            'reason' => $reason,
+        ]);
+
+        Cache::put($cacheKey, [], (int) config('notifier.announcements.failure_cache_ttl', 60));
+
+        return [];
+    }
+
+    private function cacheKey(string $baseUrl): string
+    {
+        return 'notifier.announcements.'.($this->repositoryId() ?? md5($baseUrl));
+    }
+}

--- a/src/Services/ChunkedUploadService.php
+++ b/src/Services/ChunkedUploadService.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Devuni\Notifier\Services;
 
-use GuzzleHttp\Promise\PromiseInterface;
-use Illuminate\Http\Client\Response;
-use Illuminate\Support\Facades\Http;
 use RuntimeException;
 use Throwable;
 
 final class ChunkedUploadService
 {
     public function __construct(
+        private readonly NotifierApiClient $api,
         private readonly NotifierLoggerService $notifierLogger,
     ) {}
 
@@ -27,13 +25,10 @@ final class ChunkedUploadService
     {
         $logger = $this->notifierLogger->get();
 
-        $baseUrl = config('notifier.backup_url');
+        // Validate the target up front: the shared client enforces HTTPS-only and
+        // throws before any chunking work begins if NOTIFIER_URL is missing/insecure.
+        $this->api->baseUrl();
 
-        if (! str_starts_with($baseUrl, 'https://')) {
-            throw new RuntimeException('Backup URL must use HTTPS: '.$baseUrl);
-        }
-
-        $token = config('notifier.backup_code');
         $chunkSize = (int) config('notifier.chunk_size', 20 * 1024 * 1024);
         $fileSize = filesize($path);
 
@@ -58,7 +53,7 @@ final class ChunkedUploadService
         ]);
 
         // Phase 1: Init upload
-        $uploadId = $this->initUpload($baseUrl, $token, $backupType, $filename, $fileSize, $totalChunks, $checksum);
+        $uploadId = $this->initUpload($backupType, $filename, $fileSize, $totalChunks, $checksum);
 
         $logger->info('✅ upload initialized', ['upload_id' => $uploadId]);
 
@@ -93,7 +88,7 @@ final class ChunkedUploadService
                 }
 
                 try {
-                    $this->sendChunk($baseUrl, $token, $uploadId, $chunkNumber, $tmpPath);
+                    $this->sendChunk($uploadId, $chunkNumber, $tmpPath);
                 } finally {
                     @unlink($tmpPath);
                 }
@@ -105,37 +100,29 @@ final class ChunkedUploadService
         }
 
         // Phase 3: Finalize
-        $this->finalizeUpload($baseUrl, $token, $uploadId);
+        $this->finalizeUpload($uploadId);
 
         $logger->info('✅ chunked upload finalized');
     }
 
     private function initUpload(
-        string $baseUrl,
-        string $token,
         string $backupType,
         string $filename,
         int $fileSize,
         int $totalChunks,
         string $checksum,
     ): string {
-        $response = Http::timeout(30)
-            // Never follow a redirect on a token-bearing request: Guzzle re-sends
-            // custom headers (it only strips Authorization/Cookie cross-origin), so a
-            // 30x from the backup origin would relay X-Notifier-Token to the target.
-            ->withOptions(['allow_redirects' => false])
-            ->withHeaders(['X-Notifier-Token' => $token])
-            ->post(mb_rtrim($baseUrl, '/').'/uploads/init', [
-                'backup_type' => $backupType,
-                'filename' => $filename,
-                'total_size' => $fileSize,
-                'total_chunks' => $totalChunks,
-                'checksum' => $checksum,
-            ]);
+        $response = $this->api->post('/uploads/init', [
+            'backup_type' => $backupType,
+            'filename' => $filename,
+            'total_size' => $fileSize,
+            'total_chunks' => $totalChunks,
+            'checksum' => $checksum,
+        ], 30);
 
         if (! $response->successful()) {
             throw new RuntimeException(
-                'Failed to initialize upload: HTTP '.$response->status().' - '.$this->formatErrorResponse($response)
+                'Failed to initialize upload: HTTP '.$response->status().' - '.$this->api->formatError($response)
             );
         }
 
@@ -149,8 +136,6 @@ final class ChunkedUploadService
     }
 
     private function sendChunk(
-        string $baseUrl,
-        string $token,
         string $uploadId,
         int $chunkNumber,
         string $chunkPath,
@@ -159,7 +144,7 @@ final class ChunkedUploadService
     ): void {
         $logger = $this->notifierLogger->get();
         $lastException = null;
-        $url = mb_rtrim($baseUrl, '/').'/uploads/'.$uploadId.'/chunks/'.$chunkNumber;
+        $path = '/uploads/'.$uploadId.'/chunks/'.$chunkNumber;
         $chunkChecksum = hash_file('sha256', $chunkPath);
 
         if ($chunkChecksum === false) {
@@ -174,14 +159,14 @@ final class ChunkedUploadService
                     throw new RuntimeException("Failed to open chunk file for reading: {$chunkPath}");
                 }
 
-                $response = Http::timeout(120)
-                    ->withOptions(['allow_redirects' => false])
-                    ->withHeaders([
-                        'X-Notifier-Token' => $token,
-                        'X-Chunk-Checksum' => $chunkChecksum,
-                    ])
-                    ->attach('chunk', $stream, 'chunk_'.$chunkNumber)
-                    ->post($url);
+                $response = $this->api->attachStream(
+                    $path,
+                    'chunk',
+                    $stream,
+                    'chunk_'.$chunkNumber,
+                    ['X-Chunk-Checksum' => $chunkChecksum],
+                    120,
+                );
 
                 if ($response->successful()) {
                     return;
@@ -195,11 +180,11 @@ final class ChunkedUploadService
                 } elseif ($response->status() >= 400 && $response->status() < 500) {
                     // Don't retry other 4xx errors (client mistakes)
                     throw new RuntimeException(
-                        "Chunk {$chunkNumber} rejected: HTTP ".$response->status().' - '.$this->formatErrorResponse($response)
+                        "Chunk {$chunkNumber} rejected: HTTP ".$response->status().' - '.$this->api->formatError($response)
                     );
                 } else {
                     $lastException = new RuntimeException(
-                        "Chunk {$chunkNumber} failed: HTTP ".$response->status().' - '.$this->formatErrorResponse($response)
+                        "Chunk {$chunkNumber} failed: HTTP ".$response->status().' - '.$this->api->formatError($response)
                     );
                 }
             } catch (RuntimeException $e) {
@@ -219,16 +204,13 @@ final class ChunkedUploadService
         throw $lastException ?? new RuntimeException("Chunk {$chunkNumber} failed after {$maxAttempts} attempts");
     }
 
-    private function finalizeUpload(string $baseUrl, string $token, string $uploadId): void
+    private function finalizeUpload(string $uploadId): void
     {
-        $response = Http::timeout(60)
-            ->withOptions(['allow_redirects' => false])
-            ->withHeaders(['X-Notifier-Token' => $token])
-            ->post(mb_rtrim($baseUrl, '/').'/uploads/'.$uploadId.'/finalize');
+        $response = $this->api->post('/uploads/'.$uploadId.'/finalize', [], 60);
 
         if (! $response->successful()) {
             throw new RuntimeException(
-                'Failed to finalize upload: HTTP '.$response->status().' - '.$this->formatErrorResponse($response)
+                'Failed to finalize upload: HTTP '.$response->status().' - '.$this->api->formatError($response)
             );
         }
 
@@ -243,10 +225,10 @@ final class ChunkedUploadService
 
             // The secret token is about to be attached to status_url. Never send it
             // anywhere but the configured, HTTPS backup origin - the rest of the
-            // package enforces the same HTTPS-only invariant (see upload()).
-            $this->assertTrustedStatusUrl($statusUrl, $baseUrl);
+            // package enforces the same HTTPS-only invariant (see NotifierApiClient).
+            $this->assertTrustedStatusUrl($statusUrl, $this->api->baseUrl());
 
-            $this->waitForCompletion($statusUrl, $token, $uploadId);
+            $this->waitForCompletion($statusUrl, $uploadId);
         }
     }
 
@@ -256,7 +238,6 @@ final class ChunkedUploadService
      */
     private function waitForCompletion(
         string $statusUrl,
-        string $token,
         string $uploadId,
         int $maxWaitSeconds = 1800,
         int $pollIntervalSeconds = 5,
@@ -269,10 +250,7 @@ final class ChunkedUploadService
             sleep($pollIntervalSeconds);
 
             try {
-                $response = Http::timeout(30)
-                    ->withOptions(['allow_redirects' => false])
-                    ->withHeaders(['X-Notifier-Token' => $token])
-                    ->get($statusUrl);
+                $response = $this->api->getAbsolute($statusUrl, 30);
             } catch (Throwable $e) {
                 $consecutiveErrors++;
                 $logger->warning("⚠️ status poll failed (attempt {$consecutiveErrors})", [
@@ -294,7 +272,7 @@ final class ChunkedUploadService
 
                 if ($consecutiveErrors >= 5) {
                     throw new RuntimeException(
-                        'Status polling kept returning HTTP '.$response->status().' - '.$this->formatErrorResponse($response),
+                        'Status polling kept returning HTTP '.$response->status().' - '.$this->api->formatError($response),
                     );
                 }
 
@@ -356,36 +334,5 @@ final class ChunkedUploadService
         if (($base['port'] ?? 443) !== ($target['port'] ?? 443)) {
             throw new RuntimeException('Refusing to poll status_url on unexpected port: '.$statusUrl);
         }
-    }
-
-    /**
-     * Extract a meaningful error detail from the server response.
-     *
-     * Laravel APIs typically return JSON with "message" and/or "errors" keys.
-     * Falls back to raw body if the response is not JSON.
-     */
-    private function formatErrorResponse(Response|PromiseInterface $response): string
-    {
-        $json = $response->json();
-
-        if (is_array($json)) {
-            if (isset($json['message']) && is_string($json['message'])) {
-                $detail = $json['message'];
-
-                if (isset($json['errors']) && is_array($json['errors'])) {
-                    $detail .= ' '.json_encode($json['errors'], JSON_UNESCAPED_UNICODE);
-                }
-
-                return $detail;
-            }
-
-            if (isset($json['errors']) && is_array($json['errors'])) {
-                return json_encode($json['errors'], JSON_UNESCAPED_UNICODE);
-            }
-        }
-
-        $body = $response->body();
-
-        return $body !== '' ? $body : '(empty response)';
     }
 }

--- a/src/Services/NotifierApiClient.php
+++ b/src/Services/NotifierApiClient.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\Services;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+/**
+ * The single transport to the Notifier control plane.
+ *
+ * Every authenticated request to the server goes through here, so the security
+ * invariants live in ONE place and cannot be forgotten by a new capability:
+ *   - the base URL is HTTPS-only — a misconfigured `http://` URL is refused
+ *     before the `X-Notifier-Token` secret can ride out over cleartext;
+ *   - redirects are never followed on a token-bearing request (Guzzle re-sends
+ *     custom headers across redirects, so a 30x could relay the secret elsewhere);
+ *   - the token header and the configured base URL are applied uniformly.
+ *
+ * Success/failure handling stays with the caller: a push capability throws, a
+ * pull capability swallows. This class only transports — it never decides policy.
+ */
+final class NotifierApiClient
+{
+    /**
+     * The configured, HTTPS-enforced base URL (no trailing slash).
+     *
+     * @throws RuntimeException When NOTIFIER_URL is missing or not HTTPS.
+     */
+    public function baseUrl(): string
+    {
+        $baseUrl = config('notifier.backup_url');
+
+        if (! is_string($baseUrl) || $baseUrl === '') {
+            throw new RuntimeException('Notifier URL is not configured (set NOTIFIER_URL).');
+        }
+
+        if (! str_starts_with($baseUrl, 'https://')) {
+            throw new RuntimeException('Notifier URL must use HTTPS: '.$baseUrl);
+        }
+
+        return mb_rtrim($baseUrl, '/');
+    }
+
+    /**
+     * Authenticated GET to `{baseUrl}/{path}`.
+     */
+    public function get(string $path, int $timeout = 10): Response
+    {
+        return $this->pending($timeout)->get($this->url($path));
+    }
+
+    /**
+     * Authenticated JSON POST to `{baseUrl}/{path}`.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    public function post(string $path, array $data = [], int $timeout = 30): Response
+    {
+        return $this->pending($timeout)->post($this->url($path), $data);
+    }
+
+    /**
+     * Authenticated multipart POST to `{baseUrl}/{path}` with an attached stream.
+     *
+     * @param  resource  $resource
+     * @param  array<string, string>  $headers
+     */
+    public function attachStream(string $path, string $field, $resource, string $filename, array $headers = [], int $timeout = 120): Response
+    {
+        return $this->pending($timeout)
+            ->withHeaders($headers)
+            ->attach($field, $resource, $filename)
+            ->post($this->url($path));
+    }
+
+    /**
+     * Authenticated GET to an ABSOLUTE url (e.g. a server-supplied status_url).
+     *
+     * The caller is responsible for validating the url's origin before handing
+     * the token to it — the token is attached here. See ChunkedUploadService.
+     */
+    public function getAbsolute(string $url, int $timeout = 30): Response
+    {
+        return $this->pending($timeout)->get($url);
+    }
+
+    /**
+     * Extract a meaningful error detail from a server response. Laravel APIs
+     * typically return JSON with "message" and/or "errors"; falls back to body.
+     */
+    public function formatError(Response $response): string
+    {
+        $json = $response->json();
+
+        if (is_array($json)) {
+            if (isset($json['message']) && is_string($json['message'])) {
+                $detail = $json['message'];
+
+                if (isset($json['errors']) && is_array($json['errors'])) {
+                    $detail .= ' '.json_encode($json['errors'], JSON_UNESCAPED_UNICODE);
+                }
+
+                return $detail;
+            }
+
+            if (isset($json['errors']) && is_array($json['errors'])) {
+                return json_encode($json['errors'], JSON_UNESCAPED_UNICODE);
+            }
+        }
+
+        $body = $response->body();
+
+        return $body !== '' ? $body : '(empty response)';
+    }
+
+    /**
+     * A pending request pre-loaded with the transport invariants: timeout,
+     * redirects disabled, and the X-Notifier-Token secret.
+     */
+    private function pending(int $timeout): PendingRequest
+    {
+        return Http::timeout($timeout)
+            ->withOptions(['allow_redirects' => false])
+            ->withHeaders(['X-Notifier-Token' => (string) config('notifier.backup_code')]);
+    }
+
+    private function url(string $path): string
+    {
+        return $this->baseUrl().'/'.mb_ltrim($path, '/');
+    }
+}

--- a/src/View/Components/AnnouncementsNotice.php
+++ b/src/View/Components/AnnouncementsNotice.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Devuni\Notifier\View\Components;
+
+use Devuni\Notifier\Services\AnnouncementsService;
+use Illuminate\View\Component;
+
+/**
+ * Renders this site's active maintenance/announcement announcements as notice blocks.
+ *
+ * Drop `<x-notifier-announcements-notice />` anywhere in your own dashboard. When the
+ * `announcements` feature is disabled or there is nothing to show, it renders nothing.
+ * Markup is intentionally unstyled - target the `.notifier-announcement` class (and the
+ * `.notifier-announcement--{severity}` modifier) from your own CSS.
+ */
+final class AnnouncementsNotice extends Component
+{
+    /** @var list<array<string, mixed>> */
+    public array $announcements;
+
+    public function __construct(AnnouncementsService $announcements)
+    {
+        $this->announcements = $announcements->activeAnnouncements();
+    }
+
+    public function render(): string
+    {
+        // Returning the view name (rather than a view() instance) keeps this
+        // analysable for a package-namespaced view; the component's public
+        // properties are passed to the view either way.
+        return 'notifier::components.announcements-notice';
+    }
+}

--- a/tests/Unit/Services/AnnouncementsServiceTest.php
+++ b/tests/Unit/Services/AnnouncementsServiceTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Devuni\Notifier\Services\AnnouncementsService;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'notifier.features.announcements' => true,
+        'notifier.backup_url' => 'https://notifier.devuni.cz/api/v1/repositories/52740614',
+        'notifier.backup_code' => 'super-secret-token',
+        'notifier.announcements.cache_ttl' => 900,
+        'notifier.announcements.failure_cache_ttl' => 60,
+    ]);
+});
+
+function announcementsService(): AnnouncementsService
+{
+    return app(AnnouncementsService::class);
+}
+
+describe('AnnouncementsService::activeAnnouncements', function () {
+    it('returns this site\'s announcements from the server on success', function () {
+        Http::fake([
+            '*/repositories/52740614/announcements' => Http::response([
+                'announcements' => [
+                    ['content' => 'Maintenance on 2026-06-30', 'severity' => 'warning'],
+                ],
+            ], 200),
+        ]);
+
+        $announcements = announcementsService()->activeAnnouncements();
+
+        expect($announcements)->toHaveCount(1);
+        expect($announcements[0]['content'])->toBe('Maintenance on 2026-06-30');
+    });
+
+    it('requests {backup_url}/announcements with the X-Notifier-Token header', function () {
+        Http::fake(['*' => Http::response(['announcements' => []], 200)]);
+
+        announcementsService()->activeAnnouncements();
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://notifier.devuni.cz/api/v1/repositories/52740614/announcements'
+            && $request->hasHeader('X-Notifier-Token', 'super-secret-token'));
+    });
+
+    it('returns an empty array when the announcements feature is disabled (and makes no request)', function () {
+        config(['notifier.features.announcements' => false]);
+        Http::fake(['*' => Http::response(['announcements' => [['content' => 'x']]], 200)]);
+
+        expect(announcementsService()->activeAnnouncements())->toBe([]);
+        Http::assertNothingSent();
+    });
+
+    it('returns an empty array when no backup URL is configured', function () {
+        config(['notifier.backup_url' => null]);
+        Http::fake(['*' => Http::response(['announcements' => [['content' => 'x']]], 200)]);
+
+        expect(announcementsService()->activeAnnouncements())->toBe([]);
+        Http::assertNothingSent();
+    });
+
+    it('returns an empty array (and does not throw) on a server error', function () {
+        Http::fake(['*' => Http::response('boom', 500)]);
+
+        expect(announcementsService()->activeAnnouncements())->toBe([]);
+    });
+
+    it('returns an empty array (and does not throw) on a connection failure', function () {
+        Http::fake(['*' => fn () => throw new Illuminate\Http\Client\ConnectionException('refused')]);
+
+        expect(announcementsService()->activeAnnouncements())->toBe([]);
+    });
+
+    it('caches a successful response so a second call does not hit the server', function () {
+        Http::fake(['*' => Http::response(['announcements' => [['content' => 'x']]], 200)]);
+
+        announcementsService()->activeAnnouncements();
+        announcementsService()->activeAnnouncements();
+
+        Http::assertSentCount(1);
+    });
+
+    it('negative-caches a failure so it does not retry on every call', function () {
+        Http::fake(['*' => Http::response('boom', 500)]);
+
+        announcementsService()->activeAnnouncements();
+        announcementsService()->activeAnnouncements();
+
+        Http::assertSentCount(1);
+    });
+});
+
+describe('AnnouncementsService::repositoryId', function () {
+    it('parses the repository id from the configured NOTIFIER_URL', function () {
+        expect(announcementsService()->repositoryId())->toBe('52740614');
+    });
+
+    it('returns null when the URL has no repositories segment', function () {
+        config(['notifier.backup_url' => 'https://notifier.devuni.cz/api/v1/uploads']);
+
+        expect(announcementsService()->repositoryId())->toBeNull();
+    });
+});

--- a/tests/Unit/Services/AnnouncementsServiceTest.php
+++ b/tests/Unit/Services/AnnouncementsServiceTest.php
@@ -61,6 +61,14 @@ describe('AnnouncementsService::activeAnnouncements', function () {
         Http::assertNothingSent();
     });
 
+    it('refuses to send the token over a non-HTTPS URL (never leaks the secret in cleartext)', function () {
+        config(['notifier.backup_url' => 'http://insecure.example.com/api/v1/repositories/1']);
+        Http::fake(['*' => Http::response(['announcements' => [['content' => 'x']]], 200)]);
+
+        expect(announcementsService()->activeAnnouncements())->toBe([]);
+        Http::assertNothingSent();
+    });
+
     it('returns an empty array (and does not throw) on a server error', function () {
         Http::fake(['*' => Http::response('boom', 500)]);
 

--- a/tests/Unit/Services/ChunkedUploadServiceTest.php
+++ b/tests/Unit/Services/ChunkedUploadServiceTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use Devuni\Notifier\Services\ChunkedUploadService;
-use Devuni\Notifier\Services\NotifierLoggerService;
 use Illuminate\Support\Facades\Http;
 
 /**
@@ -12,7 +11,7 @@ use Illuminate\Support\Facades\Http;
  */
 function invokeStatusUrlGuard(string $statusUrl, string $baseUrl): void
 {
-    $service = new ChunkedUploadService(new NotifierLoggerService());
+    $service = app(ChunkedUploadService::class);
     $method = new ReflectionMethod($service, 'assertTrustedStatusUrl');
     $method->setAccessible(true);
     $method->invoke($service, $statusUrl, $baseUrl);
@@ -24,10 +23,10 @@ function invokeStatusUrlGuard(string $statusUrl, string $baseUrl): void
  */
 function invokeWaitForCompletion(string $statusUrl, int $maxWaitSeconds = 10, int $pollIntervalSeconds = 0): void
 {
-    $service = new ChunkedUploadService(new NotifierLoggerService());
+    $service = app(ChunkedUploadService::class);
     $method = new ReflectionMethod($service, 'waitForCompletion');
     $method->setAccessible(true);
-    $method->invoke($service, $statusUrl, 'super-secret-token', 'upload-id', $maxWaitSeconds, $pollIntervalSeconds);
+    $method->invoke($service, $statusUrl, 'upload-id', $maxWaitSeconds, $pollIntervalSeconds);
 }
 
 describe('ChunkedUploadService::assertTrustedStatusUrl', function () {
@@ -100,7 +99,7 @@ describe('ChunkedUploadService finalize polling', function () {
 
         try {
             // The guard must fire at finalize time - before any poll/sleep happens.
-            expect(fn () => (new ChunkedUploadService(new NotifierLoggerService()))
+            expect(fn () => app(ChunkedUploadService::class)
                 ->upload($tmpPath, 'database'))
                 ->toThrow(RuntimeException::class, 'Refusing to poll status_url on unexpected host');
 
@@ -130,7 +129,7 @@ describe('ChunkedUploadService finalize polling', function () {
         file_put_contents($tmpPath, 'backup payload');
 
         try {
-            (new ChunkedUploadService(new NotifierLoggerService()))->upload($tmpPath, 'database');
+            app(ChunkedUploadService::class)->upload($tmpPath, 'database');
 
             // init + one chunk + finalize, each carrying the secret to the trusted origin.
             Http::assertSentCount(3);

--- a/tests/Unit/Services/NotifierApiClientTest.php
+++ b/tests/Unit/Services/NotifierApiClientTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Devuni\Notifier\Services\NotifierApiClient;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'notifier.backup_url' => 'https://notifier.example.com/api/v1/repositories/42',
+        'notifier.backup_code' => 'super-secret-token',
+    ]);
+});
+
+function apiClient(): NotifierApiClient
+{
+    return app(NotifierApiClient::class);
+}
+
+describe('NotifierApiClient::baseUrl', function () {
+    it('returns the configured HTTPS base URL without a trailing slash', function () {
+        config(['notifier.backup_url' => 'https://notifier.example.com/api/v1/repositories/42/']);
+
+        expect(apiClient()->baseUrl())->toBe('https://notifier.example.com/api/v1/repositories/42');
+    });
+
+    it('throws when the URL is not configured', function () {
+        config(['notifier.backup_url' => null]);
+
+        expect(fn () => apiClient()->baseUrl())->toThrow(RuntimeException::class, 'not configured');
+    });
+
+    it('throws when the URL is not HTTPS', function () {
+        config(['notifier.backup_url' => 'http://notifier.example.com']);
+
+        expect(fn () => apiClient()->baseUrl())->toThrow(RuntimeException::class, 'must use HTTPS');
+    });
+});
+
+describe('NotifierApiClient requests', function () {
+    it('GETs {baseUrl}/{path} with the token attached', function () {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        apiClient()->get('/announcements');
+
+        Http::assertSent(fn ($request) => $request->method() === 'GET'
+            && $request->url() === 'https://notifier.example.com/api/v1/repositories/42/announcements'
+            && $request->hasHeader('X-Notifier-Token', 'super-secret-token'));
+    });
+
+    it('POSTs JSON to {baseUrl}/{path} with the token', function () {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        apiClient()->post('/uploads/init', ['filename' => 'db.zip']);
+
+        Http::assertSent(fn ($request) => $request->method() === 'POST'
+            && $request->url() === 'https://notifier.example.com/api/v1/repositories/42/uploads/init'
+            && $request['filename'] === 'db.zip'
+            && $request->hasHeader('X-Notifier-Token', 'super-secret-token'));
+    });
+
+    it('GETs an absolute URL with the token (getAbsolute)', function () {
+        Http::fake(['*' => Http::response(['status' => 'completed'], 200)]);
+
+        apiClient()->getAbsolute('https://notifier.example.com/uploads/abc/status');
+
+        Http::assertSent(fn ($request) => $request->url() === 'https://notifier.example.com/uploads/abc/status'
+            && $request->hasHeader('X-Notifier-Token', 'super-secret-token'));
+    });
+
+    it('refuses to send the token when the base URL is not HTTPS', function () {
+        config(['notifier.backup_url' => 'http://insecure.example.com']);
+        Http::fake(['*' => Http::response([], 200)]);
+
+        expect(fn () => apiClient()->get('/announcements'))->toThrow(RuntimeException::class, 'must use HTTPS');
+        Http::assertNothingSent();
+    });
+});
+
+describe('NotifierApiClient::formatError', function () {
+    it('extracts the message and errors from a Laravel JSON error', function () {
+        Http::fake(['*' => Http::response(['message' => 'Validation failed', 'errors' => ['field' => ['bad']]], 422)]);
+
+        $response = apiClient()->get('/x');
+
+        expect(apiClient()->formatError($response))
+            ->toContain('Validation failed')
+            ->toContain('bad');
+    });
+
+    it('falls back to the raw body when the response is not JSON', function () {
+        Http::fake(['*' => Http::response('boom', 500)]);
+
+        $response = apiClient()->get('/x');
+
+        expect(apiClient()->formatError($response))->toBe('boom');
+    });
+});

--- a/tests/Unit/Services/NotifierDatabaseServiceTest.php
+++ b/tests/Unit/Services/NotifierDatabaseServiceTest.php
@@ -74,7 +74,7 @@ function makeNotifierDatabaseService(
     ZipCreatorInterface $zip,
 ): NotifierDatabaseService {
     return new NotifierDatabaseService(
-        new ChunkedUploadService(new NotifierLoggerService()),
+        app(ChunkedUploadService::class),
         $zip,
         $dumper,
         new NotifierLoggerService(),

--- a/tests/Unit/View/AnnouncementsFilamentBannerTest.php
+++ b/tests/Unit/View/AnnouncementsFilamentBannerTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+describe('notifier::filament.announcements', function () {
+    it('renders a styled banner for each active announcement', function () {
+        $rendered = view('notifier::filament.announcements', [
+            'announcements' => [
+                ['content' => 'Plánovaná údržba v neděli 22:00.', 'severity' => 'critical'],
+                ['content' => 'Drobná aktualizace.', 'severity' => 'info'],
+            ],
+        ])->render();
+
+        expect($rendered)
+            ->toContain('Plánovaná údržba v neděli 22:00.')
+            ->toContain('notifier-announcement--critical')
+            ->toContain('Drobná aktualizace.')
+            ->toContain('notifier-announcement--info');
+    });
+
+    it('escapes the announcement content', function () {
+        $rendered = view('notifier::filament.announcements', [
+            'announcements' => [['content' => '<script>alert(1)</script>', 'severity' => 'high']],
+        ])->render();
+
+        expect($rendered)
+            ->not->toContain('<script>alert(1)</script>')
+            ->toContain('&lt;script&gt;');
+    });
+
+    it('renders nothing when there are no announcements', function () {
+        $rendered = mb_trim(view('notifier::filament.announcements', ['announcements' => []])->render());
+
+        expect($rendered)->toBe('');
+    });
+});
+
+it('enables the announcements feature by default', function () {
+    expect(config('notifier.features.announcements'))->toBeTrue()
+        ->and(config('notifier.announcements.filament.enabled'))->toBeTrue()
+        ->and(config('notifier.announcements.filament.render_hook'))->toBe('panels::content.start');
+});

--- a/tests/Unit/View/AnnouncementsNoticeTest.php
+++ b/tests/Unit/View/AnnouncementsNoticeTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    config([
+        'notifier.features.announcements' => true,
+        'notifier.backup_url' => 'https://notifier.devuni.cz/api/v1/repositories/52740614',
+        'notifier.backup_code' => 'super-secret-token',
+    ]);
+});
+
+describe('<x-notifier-announcements-notice />', function () {
+    it('renders the announcement content when an announcement is active', function () {
+        Http::fake([
+            '*/announcements' => Http::response([
+                'announcements' => [
+                    ['content' => 'Maintenance on 2026-06-30, ~5h downtime.', 'severity' => 'warning'],
+                ],
+            ], 200),
+        ]);
+
+        $this->blade('<x-notifier-announcements-notice />')
+            ->assertSee('Maintenance on 2026-06-30, ~5h downtime.')
+            ->assertSee('notifier-announcement--warning', false);
+    });
+
+    it('renders nothing when there are no active announcements', function () {
+        Http::fake(['*/announcements' => Http::response(['announcements' => []], 200)]);
+
+        $rendered = mb_trim($this->blade('<x-notifier-announcements-notice />')->__toString());
+
+        expect($rendered)->toBe('');
+    });
+
+    it('renders nothing when the feature is disabled', function () {
+        config(['notifier.features.announcements' => false]);
+        Http::fake(['*' => Http::response(['announcements' => [['content' => 'x']]], 200)]);
+
+        $rendered = mb_trim($this->blade('<x-notifier-announcements-notice />')->__toString());
+
+        expect($rendered)->toBe('');
+        Http::assertNothingSent();
+    });
+});


### PR DESCRIPTION
## 2.8.0 — Announcements + transport hardening

Client side of the platform's maintenance/announcement feature (pairs with the matching server endpoint on `notifier-devuni-cz`).

### Added
- **Announcements** — pull this site's active maintenance/announcement notices (`GET {NOTIFIER_URL}/announcements`, per-repository, reuses the existing `X-Notifier-Token`). Cached + fail-open, so a down/slow server never breaks the dashboard. **On by default** (no-ops until `NOTIFIER_URL` is set).
- **Filament auto-injection** — the notices are auto-injected as a styled banner into every Filament panel page (v3/v4/v5) via a render hook. Configurable (`NOTIFIER_ANNOUNCEMENTS_FILAMENT[_HOOK]`), registered only when Filament is installed.
- **Blade component** `<x-notifier-announcements-notice />` + framework-agnostic `AnnouncementsService::activeAnnouncements()` for Inertia/Vue/React hosts.

### Changed / Security
- **`NotifierApiClient`** — all server communication now flows through a single transport (HTTPS-only enforcement, `X-Notifier-Token`, redirect-disabling, base-URL resolution, JSON error formatting). This **fixes a gap** where the announcements pull did not enforce HTTPS, so a misconfigured `http://` `NOTIFIER_URL` could have sent the token over cleartext. Backup-upload behaviour is unchanged; all existing security tests (status_url guard, finalize polling) pass.

### Tests
194 passed locally (the 3 failures are a missing local `pg_dump` binary only; CI runners have it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
